### PR TITLE
Add operation descriptions and info.contact (v1.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-04-05
+
+### Added
+- `description` field on all 16 operations (resolves Spectral `operation-description` warnings)
+- `contact` field in `info` object (resolves Spectral `info-contact` warning)
+
 ## [1.0.0] - 2026-04-04
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@glebremniov/budget-buddy-contracts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@glebremniov/budget-buddy-contracts",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "devDependencies": {
         "@openapitools/openapi-generator-cli": "^2.31.0",
         "@stoplight/spectral-cli": "^6.15.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glebremniov/budget-buddy-contracts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "API-first contracts for Budget Buddy — OpenAPI spec + generated clients",
   "private": true,
   "scripts": {

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -3,7 +3,10 @@ openapi: 3.1.0
 info:
   title: Budget Buddy API
   description: REST API for Budget Buddy.
-  version: "1.0.0"
+  version: "1.0.1"
+  contact:
+    name: Budget Buddy
+    url: https://github.com/glebremniov/budget-buddy-contracts
 
 servers:
   - url: https://api.example.com
@@ -24,6 +27,7 @@ paths:
     post:
       tags: [ auth ]
       summary: Authenticate user
+      description: Authenticates a user with username and password, returning access and refresh tokens.
       operationId: loginUser
       security: [ ]
       requestBody:
@@ -46,6 +50,7 @@ paths:
     post:
       tags: [ auth ]
       summary: Refresh access token
+      description: Exchanges a valid refresh token for a new access token.
       operationId: refreshToken
       security: [ ]
       requestBody:
@@ -68,6 +73,7 @@ paths:
     post:
       tags: [ auth ]
       summary: Register new user
+      description: Creates a new user account with the provided credentials.
       operationId: registerUser
       security: [ ]
       requestBody:
@@ -88,6 +94,7 @@ paths:
     post:
       tags: [ auth ]
       summary: Logout user and invalidate refresh tokens
+      description: Invalidates the current user's refresh tokens, ending their session.
       operationId: logoutUser
       responses:
         "204":
@@ -99,6 +106,7 @@ paths:
     get:
       tags: [ categories ]
       summary: List categories
+      description: Returns a paginated list of categories for the authenticated user.
       operationId: listCategories
       parameters:
         - $ref: "#/components/parameters/limit"
@@ -116,6 +124,7 @@ paths:
     post:
       tags: [ categories ]
       summary: Create category
+      description: Creates a new category and returns the created resource with its assigned ID.
       operationId: createCategory
       requestBody:
         required: true
@@ -148,6 +157,7 @@ paths:
     get:
       tags: [ categories ]
       summary: Get category
+      description: Returns a single category by its UUID.
       operationId: getCategory
       responses:
         "200":
@@ -164,6 +174,7 @@ paths:
     put:
       tags: [ categories ]
       summary: Replace category
+      description: Fully replaces a category's data (PUT semantics).
       operationId: replaceCategory
       requestBody:
         required: true
@@ -188,6 +199,7 @@ paths:
     patch:
       tags: [ categories ]
       summary: Partially update category
+      description: Partially updates a category; only provided fields are modified.
       operationId: updateCategory
       requestBody:
         required: true
@@ -212,6 +224,7 @@ paths:
     delete:
       tags: [ categories ]
       summary: Delete category
+      description: Permanently deletes a category by its UUID.
       operationId: deleteCategory
       responses:
         "204":
@@ -225,6 +238,7 @@ paths:
     get:
       tags: [ transactions ]
       summary: List transactions
+      description: Returns a paginated, filterable list of transactions for the authenticated user.
       operationId: listTransactions
       parameters:
         - $ref: "#/components/parameters/limit"
@@ -269,6 +283,7 @@ paths:
     post:
       tags: [ transactions ]
       summary: Create transaction
+      description: Records a new transaction and returns the created resource.
       operationId: createTransaction
       requestBody:
         required: true
@@ -300,6 +315,7 @@ paths:
     get:
       tags: [ transactions ]
       summary: Get transaction
+      description: Returns a single transaction by its UUID.
       operationId: getTransaction
       responses:
         "200":
@@ -316,6 +332,7 @@ paths:
     put:
       tags: [ transactions ]
       summary: Replace transaction
+      description: Fully replaces a transaction's data (PUT semantics).
       operationId: replaceTransaction
       requestBody:
         required: true
@@ -340,6 +357,7 @@ paths:
     patch:
       tags: [ transactions ]
       summary: Partially update transaction
+      description: Partially updates a transaction; only provided fields are modified.
       operationId: updateTransaction
       requestBody:
         required: true
@@ -364,6 +382,7 @@ paths:
     delete:
       tags: [ transactions ]
       summary: Delete transaction
+      description: Permanently deletes a transaction by its UUID.
       operationId: deleteTransaction
       responses:
         "204":


### PR DESCRIPTION
## Why

All 16 operations were missing `description` fields, causing Spectral to emit `operation-description` warnings on every CI run. The `info` block also lacked a `contact` field, triggering an `info-contact` warning. This cleans up all Spectral warnings and improves generated client documentation.

## What changed

- **`specs/openapi.yaml`** — Added `description` to all 16 operations across `auth`, `categories`, and `transactions` tags; added `contact` block to `info`
- **`specs/openapi.yaml`, `package.json`, `package-lock.json`** — Bumped version `1.0.0` → `1.0.1` (PATCH: doc-only change that affects generated JSDoc/Javadoc output)
- **`CHANGELOG.md`** — Added `[1.0.1]` entry documenting both additions

## How to verify

1. `npm run lint` — should produce zero warnings (previously showed `operation-description` and `info-contact` warnings)
2. `npm run validate` — should pass cleanly
3. Check that each operation in `specs/openapi.yaml` now has a `description` field
4. Confirm `info.contact` is present in the spec

## Notes

Per the versioning strategy in CLAUDE.md, doc/comment changes that affect generated output (descriptions flow into JSDoc/Javadoc) warrant a PATCH bump. Config-only changes with no generated-output impact would not require a bump.