### PR TITLE
Add Claude CLI custom commands

### DIFF
--- a/.claude/commands/add-endpoint.md
+++ b/.claude/commands/add-endpoint.md
@@ -1,0 +1,23 @@
+Add a new endpoint to `specs/openapi.yaml` following project conventions.
+
+The user will describe the endpoint they want. Based on their description:
+
+1. Read `specs/openapi.yaml` to understand the existing structure, schemas, and patterns before making changes.
+
+2. Add the path and operation following these conventions:
+   - Every operation MUST have a unique `operationId` in camelCase (e.g. `listTransactions`, `createBudget`) — Spectral enforces this
+   - Every operation MUST have at least one tag (use existing tags when applicable)
+   - Include appropriate HTTP status codes for success responses
+   - All error responses use `application/problem+json` with `$ref: '#/components/schemas/Problem'`
+   - Monetary amounts are `integer` in minor currency units (e.g. `1299` = €12.99) — never `number` or `string`
+   - Use `$ref` to reference shared schemas; never inline schemas that are reused
+
+3. Add schemas to `components/schemas` if needed:
+   - Write schemas (POST/PUT body): name them `Create<Resource>Request` or `Update<Resource>Request`
+   - PATCH body schemas: name them `Patch<Resource>Request`  
+   - Read schemas (response body): name them `<Resource>` or `<Resource>Response`
+   - Keep write and read schemas separate
+
+4. After editing, run `npm run lint && npm run validate` and fix any errors before finishing.
+
+5. Report what was added: path, operationId, new schemas (if any), and remind the user to run `/release` when ready to publish.

--- a/.claude/commands/lint-fix.md
+++ b/.claude/commands/lint-fix.md
@@ -1,0 +1,14 @@
+Run the spec linter and validator, then fix any errors found.
+
+1. Run `npm run lint` (Spectral) and capture output
+2. Run `npm run validate` (openapi-generator structural validation) and capture output
+3. If both pass with no errors, report success and stop
+4. For any errors:
+   - Read the relevant section of `specs/openapi.yaml` before editing
+   - Fix each error in place — common issues:
+     - Missing `operationId`: add a camelCase one derived from the HTTP method + path (e.g. `GET /budgets/{id}` → `getBudget`)
+     - Missing `tags`: add an appropriate tag matching the resource name
+     - Schema type errors: check OAS 3.1 syntax (nullable uses `type: [string, "null"]`, not `nullable: true`)
+     - `$ref` pointing to undefined component: add the missing schema or correct the reference path
+5. Re-run both commands after fixes to confirm clean output
+6. Show a summary of what was changed

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,18 @@
+Run the full release workflow for budget-buddy-contracts.
+
+Steps:
+1. Run `npm run lint` — must pass with no errors before proceeding
+2. Run `npm run validate` — must pass before proceeding
+3. Run `npm run generate:swift` and commit any changes in `Sources/BudgetBuddyContracts/` with message `chore: regenerate Swift sources for vX.Y.Z`
+4. Determine the bump type (patch/minor/major) based on what changed in `specs/openapi.yaml` since the last tag:
+   - MAJOR — removed endpoint, changed required field, renamed operationId
+   - MINOR — new endpoint, new optional field
+   - PATCH — generator config tweak, doc/comment update
+   If `$ARGUMENTS` is provided (e.g. `patch`, `minor`, `major`), use that instead.
+5. Compute the new version by incrementing `package.json`'s current version accordingly
+6. Update `version` in `package.json` and `info.version` in `specs/openapi.yaml` to the new version — they must match
+7. Add a new entry to the top of `CHANGELOG.md` under the new version with today's date and a summary of changes
+8. Commit all changes: `git add package.json specs/openapi.yaml CHANGELOG.md Sources/` with message `chore: release vX.Y.Z`
+9. Show the user the planned git tag command and ask for confirmation before tagging:
+   `git tag vX.Y.Z && git push --follow-tags`
+   Explain that pushing the tag triggers CI to generate TypeScript + Java and publish both to GitHub Packages.


### PR DESCRIPTION
This PR adds custom commands for the Claude CLI to automate common tasks in the repository:
- `add-endpoint`: Workflow for adding new endpoints to `specs/openapi.yaml`
- `lint-fix`: Automated linting and fixing of the OpenAPI specification
- `release`: Full release workflow, including Swift code regeneration, version bumping, and changelog updates.