### PR TITLE
feat(contracts): update 1.1.0 patch semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-04-09
+
+### Changed
+- aligned Problem Details references with RFC 9457
+- replaced the placeholder production server URL with a templated server that defaults generated clients to `http://localhost:8080`
+- clarified create-response `Location` headers across category and transaction endpoints
+- made `CategoryUpdate` a true PATCH schema with optional fields and a non-empty object requirement
+- required non-empty PATCH documents for `TransactionUpdate` as well
+
 ## [1.0.1] - 2026-04-05
 
 ### Added
@@ -18,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - OpenAPI 3.1.0 spec with auth, categories, and transactions endpoints
 - JWT Bearer security scheme (global, except auth endpoints)
-- RFC 7807 Problem+JSON error responses
+- RFC 9457 Problem Details error responses
 - Separate Write/Update schemas for clean POST/PUT/PATCH semantics
 - Pagination with limit/offset on list endpoints
 - TypeScript axios client generation config (GitHub Packages)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,9 @@ API-first contracts for Budget Buddy. The OpenAPI spec in `specs/openapi.yaml` i
 |--------|-----------|--------|-------------|
 | TypeScript | `typescript-axios` | `generated/typescript/` | GitHub Packages (npm) |
 | Java Spring Boot | `spring` (interfaceOnly) | `generated/java/` | GitHub Packages (Maven) |
-| iOS/Swift | `swift5` (urlsession) | `Sources/BudgetBuddyContracts/` | Git repo (SPM) |
+| iOS/Swift | `swift6` | `Sources/BudgetBuddyContracts/` | Git repo (SPM) |
 
-`generated/` is gitignored — TypeScript and Java are ephemeral CI artifacts. `Sources/BudgetBuddyContracts/` is committed because Swift Package Manager requires sources tracked in git.
+`generated/` is gitignored — TypeScript and Java are ephemeral CI/local artifacts. `Sources/BudgetBuddyContracts/` is committed because Swift Package Manager requires sources tracked in git.
 
 ## Commands
 
@@ -69,7 +69,8 @@ Semver:
 ## Spec conventions
 
 - All operations have an `operationId` (required by Spectral, used for generated method names)
-- Error responses use `application/problem+json` with the `Problem` schema (RFC 7807)
+- Error responses use `application/problem+json` with the `Problem` schema (RFC 9457)
 - Amounts are `integer` in minor currency units (e.g. `1299` = €12.99)
 - Write schemas (POST/PUT body) and Update schemas (PATCH body) are separate from read schemas
+- PATCH schemas represent partial updates: fields are optional, and empty patch objects are invalid
 - Auth endpoints override global security with `security: []`

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The core of this project is the OpenAPI specification located in `specs/openapi.
 - **Type Safety:** Eliminate runtime errors caused by mismatched API schemas.
 - **Parallel Development:** Frontend, Backend, and Mobile teams can work simultaneously against a shared interface.
 - **Documentation:** The spec *is* the documentation.
-- **Consistency:** Standardized error handling (RFC 7807) across all platforms.
+- **Consistency:** Standardized error handling (RFC 9457) across all platforms.
 
 ---
 
@@ -58,7 +58,7 @@ npm install
 Add this repository as a dependency in your `Package.swift`:
 ```swift
 dependencies: [
-    .package(url: "https://github.com/glebremniov/budget-buddy-contracts.git", from: "1.0.1")
+    .package(url: "https://github.com/glebremniov/budget-buddy-contracts.git", from: "1.1.0")
 ]
 ```
 
@@ -74,7 +74,7 @@ Add to your `pom.xml`:
 <dependency>
     <groupId>com.budgetbuddy</groupId>
     <artifactId>budget-buddy-contracts</artifactId>
-    <version>1.0.1</version>
+    <version>1.1.0</version>
 </dependency>
 ```
 
@@ -97,6 +97,6 @@ Add to your `pom.xml`:
 ## 📝 API Design Conventions
 
 - **Currency:** All monetary amounts are handled as `integers` in minor units (e.g., `$10.50` is represented as `1050`).
-- **Errors:** We follow **RFC 7807** (Problem Details for HTTP APIs). Every error response uses the `application/problem+json` content type.
+- **Errors:** We follow **RFC 9457** (Problem Details for HTTP APIs). Every error response uses the `application/problem+json` content type.
 - **Pagination:** Collections use a standardized `PaginationMeta` object containing `total`, `limit`, and `offset`.
 - **Auth:** Bearer Token (JWT) is used globally except for login/register endpoints.

--- a/Sources/BudgetBuddyContracts/APIs/AuthAPI.swift
+++ b/Sources/BudgetBuddyContracts/APIs/AuthAPI.swift
@@ -23,6 +23,7 @@ open class AuthAPI {
     /**
      Authenticate user
      - POST /v1/auth/login
+     - Authenticates a user with username and password, returning access and refresh tokens.
      - parameter loginRequest: (body)  
      - parameter apiConfiguration: The configuration for the http request.
      - returns: RequestBuilder<AuthToken> 
@@ -58,6 +59,7 @@ open class AuthAPI {
     /**
      Logout user and invalidate refresh tokens
      - POST /v1/auth/logout
+     - Invalidates the current user's refresh tokens, ending their session.
      - Bearer Token:
        - type: http
        - name: BearerAuth
@@ -96,6 +98,7 @@ open class AuthAPI {
     /**
      Refresh access token
      - POST /v1/auth/refresh
+     - Exchanges a valid refresh token for a new access token.
      - parameter refreshTokenRequest: (body)  
      - parameter apiConfiguration: The configuration for the http request.
      - returns: RequestBuilder<AuthToken> 
@@ -132,6 +135,7 @@ open class AuthAPI {
     /**
      Register new user
      - POST /v1/auth/register
+     - Creates a new user account with the provided credentials.
      - parameter registerRequest: (body)  
      - parameter apiConfiguration: The configuration for the http request.
      - returns: RequestBuilder<Void> 

--- a/Sources/BudgetBuddyContracts/APIs/CategoriesAPI.swift
+++ b/Sources/BudgetBuddyContracts/APIs/CategoriesAPI.swift
@@ -23,6 +23,7 @@ open class CategoriesAPI {
     /**
      Create category
      - POST /v1/categories
+     - Creates a new category and returns the created resource with its assigned ID.
      - Bearer Token:
        - type: http
        - name: BearerAuth
@@ -63,6 +64,7 @@ open class CategoriesAPI {
     /**
      Delete category
      - DELETE /v1/categories/{categoryId}
+     - Permanently deletes a category by its UUID.
      - Bearer Token:
        - type: http
        - name: BearerAuth
@@ -105,6 +107,7 @@ open class CategoriesAPI {
     /**
      Get category
      - GET /v1/categories/{categoryId}
+     - Returns a single category by its UUID.
      - Bearer Token:
        - type: http
        - name: BearerAuth
@@ -148,6 +151,7 @@ open class CategoriesAPI {
     /**
      List categories
      - GET /v1/categories
+     - Returns a paginated list of categories for the authenticated user.
      - Bearer Token:
        - type: http
        - name: BearerAuth
@@ -193,6 +197,7 @@ open class CategoriesAPI {
     /**
      Replace category
      - PUT /v1/categories/{categoryId}
+     - Fully replaces a category's data (PUT semantics).
      - Bearer Token:
        - type: http
        - name: BearerAuth
@@ -237,6 +242,7 @@ open class CategoriesAPI {
     /**
      Partially update category
      - PATCH /v1/categories/{categoryId}
+     - Partially updates a category; only provided fields are modified. Empty patch objects are invalid and return 400.
      - Bearer Token:
        - type: http
        - name: BearerAuth

--- a/Sources/BudgetBuddyContracts/APIs/TransactionsAPI.swift
+++ b/Sources/BudgetBuddyContracts/APIs/TransactionsAPI.swift
@@ -23,6 +23,7 @@ open class TransactionsAPI {
     /**
      Create transaction
      - POST /v1/transactions
+     - Records a new transaction and returns the created resource.
      - Bearer Token:
        - type: http
        - name: BearerAuth
@@ -63,6 +64,7 @@ open class TransactionsAPI {
     /**
      Delete transaction
      - DELETE /v1/transactions/{transactionId}
+     - Permanently deletes a transaction by its UUID.
      - Bearer Token:
        - type: http
        - name: BearerAuth
@@ -105,6 +107,7 @@ open class TransactionsAPI {
     /**
      Get transaction
      - GET /v1/transactions/{transactionId}
+     - Returns a single transaction by its UUID.
      - Bearer Token:
        - type: http
        - name: BearerAuth
@@ -160,6 +163,7 @@ open class TransactionsAPI {
     /**
      List transactions
      - GET /v1/transactions
+     - Returns a paginated, filterable list of transactions for the authenticated user.
      - Bearer Token:
        - type: http
        - name: BearerAuth
@@ -213,6 +217,7 @@ open class TransactionsAPI {
     /**
      Replace transaction
      - PUT /v1/transactions/{transactionId}
+     - Fully replaces a transaction's data (PUT semantics).
      - Bearer Token:
        - type: http
        - name: BearerAuth
@@ -257,6 +262,7 @@ open class TransactionsAPI {
     /**
      Partially update transaction
      - PATCH /v1/transactions/{transactionId}
+     - Partially updates a transaction; only provided fields are modified. Empty patch objects are invalid and return 400.
      - Bearer Token:
        - type: http
        - name: BearerAuth

--- a/Sources/BudgetBuddyContracts/Infrastructure/APIs.swift
+++ b/Sources/BudgetBuddyContracts/Infrastructure/APIs.swift
@@ -25,7 +25,7 @@ open class BudgetBuddyContractsAPIConfiguration: @unchecked Sendable {
     public var interceptor: OpenAPIInterceptor
 
     public init(
-        basePath: String = "https://api.example.com",
+        basePath: String = "http://localhost:8080",
         customHeaders: [String: String] = [:],
         credential: URLCredential? = nil,
         requestBuilderFactory: RequestBuilderFactory = URLSessionRequestBuilderFactory(),

--- a/Sources/BudgetBuddyContracts/Models/CategoryUpdate.swift
+++ b/Sources/BudgetBuddyContracts/Models/CategoryUpdate.swift
@@ -7,13 +7,13 @@
 
 import Foundation
 
-/** Patch request — only provided fields will be updated */
+/** Patch request — only provided fields are updated. At least one field must be provided. */
 public struct CategoryUpdate: Sendable, Codable, Hashable {
 
     public static let nameRule = StringRule(minLength: 1, maxLength: 255, pattern: nil)
-    public var name: String
+    public var name: String?
 
-    public init(name: String) {
+    public init(name: String? = nil) {
         self.name = name
     }
 
@@ -25,7 +25,7 @@ public struct CategoryUpdate: Sendable, Codable, Hashable {
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(name, forKey: .name)
+        try container.encodeIfPresent(name, forKey: .name)
     }
 }
 

--- a/Sources/BudgetBuddyContracts/Models/Problem.swift
+++ b/Sources/BudgetBuddyContracts/Models/Problem.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-/** RFC 7807 Problem+JSON */
+/** RFC 9457 Problem Details */
 public struct Problem: Sendable, Codable, Hashable {
 
     public var type: String? = "about:blank"

--- a/Sources/BudgetBuddyContracts/Models/TransactionUpdate.swift
+++ b/Sources/BudgetBuddyContracts/Models/TransactionUpdate.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-/** Patch request — only provided fields will be updated */
+/** Patch request — only provided fields are updated. At least one field must be provided. */
 public struct TransactionUpdate: Sendable, Codable, Hashable {
 
     public enum ModelType: String, Sendable, Codable, CaseIterable {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@glebremniov/budget-buddy-contracts",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@glebremniov/budget-buddy-contracts",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "devDependencies": {
         "@openapitools/openapi-generator-cli": "^2.31.1",
         "@stoplight/spectral-cli": "^6.15.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glebremniov/budget-buddy-contracts",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "API-first contracts for Budget Buddy — OpenAPI spec + generated clients",
   "private": true,
   "type": "module",

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -3,16 +3,22 @@ openapi: 3.1.0
 info:
   title: Budget Buddy API
   description: REST API for Budget Buddy.
-  version: "1.0.1"
+  version: "1.1.0"
   contact:
     name: Budget Buddy
     url: https://github.com/glebremniov/budget-buddy-contracts
 
 servers:
-  - url: https://api.example.com
-    description: Production
-  - url: http://localhost:8080
-    description: Local development
+  - url: "{scheme}://{host}"
+    description: Configurable Budget Buddy API server
+    variables:
+      scheme:
+        default: http
+        enum:
+          - http
+          - https
+      host:
+        default: localhost:8080
 
 tags:
   - name: auth
@@ -137,7 +143,7 @@ paths:
           description: Category created
           headers:
             Location:
-              description: URL of created category
+              description: URL of created resource
               schema:
                 type: string
                 format: uri
@@ -199,7 +205,7 @@ paths:
     patch:
       tags: [ categories ]
       summary: Partially update category
-      description: Partially updates a category; only provided fields are modified.
+      description: Partially updates a category; only provided fields are modified. Empty patch objects are invalid and return 400.
       operationId: updateCategory
       requestBody:
         required: true
@@ -296,6 +302,7 @@ paths:
           description: Transaction created
           headers:
             Location:
+              description: URL of created resource
               schema:
                 type: string
                 format: uri
@@ -357,7 +364,7 @@ paths:
     patch:
       tags: [ transactions ]
       summary: Partially update transaction
-      description: Partially updates a transaction; only provided fields are modified.
+      description: Partially updates a transaction; only provided fields are modified. Empty patch objects are invalid and return 400.
       operationId: updateTransaction
       requestBody:
         required: true
@@ -548,8 +555,8 @@ components:
 
     CategoryUpdate:
       type: object
-      required: [ name ]
-      description: Patch request — only provided fields will be updated
+      description: Patch request — only provided fields are updated. At least one field must be provided.
+      minProperties: 1
       properties:
         name:
           type: string
@@ -624,7 +631,8 @@ components:
 
     TransactionUpdate:
       type: object
-      description: Patch request — only provided fields will be updated
+      description: Patch request — only provided fields are updated. At least one field must be provided.
+      minProperties: 1
       properties:
         categoryId:
           type: string
@@ -681,7 +689,7 @@ components:
 
     Problem:
       type: object
-      description: RFC 7807 Problem+JSON
+      description: RFC 9457 Problem Details
       required: [ title, status ]
       properties:
         type:


### PR DESCRIPTION
## Summary
- update the OpenAPI contract for correct PATCH semantics and RFC 9457 Problem Details wording
- replace the placeholder production server URL with a templated server that defaults to `http://localhost:8080`
- bump the contracts version to `1.1.0` and refresh repo docs/guidance

## Changes
- make `CategoryUpdate` a true PATCH schema with optional fields and `minProperties: 1`
- require non-empty PATCH documents for `TransactionUpdate` as well
- clarify category/transaction PATCH operations to reject empty patch objects with `400`
- align create-response `Location` header descriptions
- regenerate committed Swift sources from the updated spec
- update `README.md`, `CHANGELOG.md`, and `CLAUDE.md`

## Validation
- `npm run lint`
- OpenAPI validation via locally cached `openapi-generator-cli` 7.21.0 JAR
- regenerated TypeScript and Swift clients locally to verify the updated contract surface
