### PR TITLE
Fix: replace semantic-release-openapi with exec sed (v25 compat)

### DIFF
--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -11,15 +11,10 @@ module.exports = {
       },
     ],
     [
-      "semantic-release-openapi",
-      {
-        apiSpecFiles: ["specs/openapi.yaml"],
-      },
-    ],
-    [
       "@semantic-release/exec",
       {
-        prepareCmd: "pnpm run generate:swift",
+        prepareCmd:
+          "sed -i 's/^  version: .*/  version: \"${nextRelease.version}\"/' specs/openapi.yaml && pnpm run generate:swift",
       },
     ],
     [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - introduced semantic-release for fully automated versioning and publishing on push to `main`
 
 ### Fixed
-- `specs/openapi.yaml` was never version-bumped in release commits because `semantic-release-openapi` ran after `@semantic-release/git`; reordered plugins so the openapi spec is updated before the commit
+- replaced `semantic-release-openapi` (incompatible with semantic-release v25) with a direct `sed` command via `@semantic-release/exec` to bump `specs/openapi.yaml` version during prepare
 - TypeScript and Java clients were never generated or published after a release because all four conditional steps referenced the non-existent step ID `after` instead of `detect`
 - Swift sources (`Sources/BudgetBuddyContracts/`) are now regenerated during the semantic-release prepare phase via `@semantic-release/exec`, ensuring the tagged commit always contains up-to-date generated sources (required for SPM resolution)
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@stoplight/prism-cli": "^5.14.2",
     "@stoplight/spectral-cli": "^6.15.0",
     "husky": "^9.1.7",
-    "semantic-release": "^25.0.3",
-    "semantic-release-openapi": "^1.5.1"
+    "semantic-release": "^25.0.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,9 +50,6 @@ importers:
       semantic-release:
         specifier: ^25.0.3
         version: 25.0.3(typescript@6.0.2)
-      semantic-release-openapi:
-        specifier: ^1.5.1
-        version: 1.5.1(semantic-release@25.0.3(typescript@6.0.2))
 
 packages:
 
@@ -2389,11 +2386,6 @@ packages:
     resolution: {integrity: sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==}
     engines: {node: '>=14'}
 
-  replace-in-file@8.4.0:
-    resolution: {integrity: sha512-D28k8jy2LtUGbCzCnR3znajaTWIjJ/Uee3UdodzcHRxE7zn6NmYW/dcSqyivnsYU3W+MxdX6SbF28NvJ0GRoLA==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -2461,12 +2453,6 @@ packages:
 
   seedrandom@3.0.5:
     resolution: {integrity: sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==}
-
-  semantic-release-openapi@1.5.1:
-    resolution: {integrity: sha512-hv5/LDcDAsAILP0T29YBkxMv7+HauGueMnL1ayDEGuFQaRVXv4r2AOD0D4Eab89/hOXnxv36oTckHgZkB6vbNw==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      semantic-release: '>=20.0.0'
 
   semantic-release@25.0.3:
     resolution: {integrity: sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==}
@@ -5706,12 +5692,6 @@ snapshots:
     dependencies:
       '@pnpm/npm-conf': 3.0.2
 
-  replace-in-file@8.4.0:
-    dependencies:
-      chalk: 5.6.2
-      glob: 13.0.6
-      yargs: 18.0.0
-
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -5770,15 +5750,6 @@ snapshots:
   safer-buffer@2.1.2: {}
 
   seedrandom@3.0.5: {}
-
-  semantic-release-openapi@1.5.1(semantic-release@25.0.3(typescript@6.0.2)):
-    dependencies:
-      '@semantic-release/error': 4.0.0
-      fdir: 6.5.0(picomatch@4.0.4)
-      fs-extra: 11.3.4
-      picomatch: 4.0.4
-      replace-in-file: 8.4.0
-      semantic-release: 25.0.3(typescript@6.0.2)
 
   semantic-release@25.0.3(typescript@6.0.2):
     dependencies:


### PR DESCRIPTION
## Why

The previous PR (#31) merged and immediately failed in CI: `semantic-release-openapi@1.5.1` crashes with `semantic-release@25` due to an internal API removal (`TypeError: Cannot read properties of undefined (reading 'sync')`). The plugin is unmaintained against v25.

## What changed

- **Removed `semantic-release-openapi`** from `.releaserc.cjs` and `package.json` — incompatible with semantic-release v25
- **Replaced with a `sed` one-liner** in the existing `@semantic-release/exec` `prepareCmd` that updates `specs/openapi.yaml` before the git commit step, chained with the Swift generation:
  ```
  sed -i 's/^  version: .*/  version: "${nextRelease.version}"/' specs/openapi.yaml && pnpm run generate:swift
  ```
- Updated `CHANGELOG.md` to reflect the actual fix

## How to verify

1. Merge this PR to `main`
2. Watch the `Release` workflow — the semantic-release prepare step should complete without crashing
3. Confirm the release commit contains the bumped version in both `package.json` and `specs/openapi.yaml`