### PR TITLE
feat(release): use GitHub App token for protected-branch push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,8 @@ jobs:
       - uses: actions/create-github-app-token@v1
         id: app-token
         with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.RELEASE_BOT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,16 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: pnpm/action-setup@v5
         with:
@@ -45,8 +52,8 @@ jobs:
 
       - name: Run semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          NODE_AUTH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: pnpm exec semantic-release
 
       - name: Detect release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - replaced `semantic-release-openapi` (incompatible with semantic-release v25) with a direct `sed` command via `@semantic-release/exec` to bump `specs/openapi.yaml` version during prepare
 - TypeScript and Java clients were never generated or published after a release because all four conditional steps referenced the non-existent step ID `after` instead of `detect`
 - Swift sources (`Sources/BudgetBuddyContracts/`) are now regenerated during the semantic-release prepare phase via `@semantic-release/exec`, ensuring the tagged commit always contains up-to-date generated sources (required for SPM resolution)
+- `@semantic-release/git` was blocked by the branch ruleset PR requirement when pushing the version-bump commit; switched to a GitHub App token (`RELEASE_BOT_ID` + `RELEASE_BOT_PRIVATE_KEY`) via `actions/create-github-app-token` — the app is added to the Ruleset bypass actor list so CI can push directly while the PR requirement still applies to human contributors
 
 ## [1.1.0] - 2026-04-09
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,8 +73,8 @@ Do **not** manually bump versions, tag, or run `generate:swift` before merging �
 - `Package.swift` — makes this repo a valid Swift Package; points to `Sources/BudgetBuddyContracts/`
 - `.spectral.yaml` — enforces `operationId` on every operation (error) and tags (warn); generators rely on both
 - `.github/workflows/validate.yml` — runs lint + validate on PRs that touch `specs/` or `config/`
-- `.github/workflows/release.yml` — on push to `main`: runs semantic-release, then generates and publishes TypeScript (npm) + Java (Maven) to GitHub Packages using `GITHUB_TOKEN`
-- `.releaserc.cjs` — semantic-release plugin config; plugin order matters (openapi → exec/swift → git commit)
+- `.github/workflows/release.yml` — on push to `main`: generates a GitHub App token (`RELEASE_BOT_ID` + `RELEASE_BOT_PRIVATE_KEY` org secrets) to bypass the branch ruleset PR requirement, then runs semantic-release and publishes TypeScript (npm) + Java (Maven) to GitHub Packages
+- `.releaserc.cjs` — semantic-release plugin config; plugin order matters (changelog → npm → exec/swift → git commit → github)
 
 ## Spec conventions
 


### PR DESCRIPTION
## Why

\`@semantic-release/git\` pushes a version-bump commit directly to \`main\` after each release. The default \`GITHUB_TOKEN\` is blocked by the branch ruleset that requires a pull request, causing every release run to fail with a 403. A GitHub App added to the Ruleset bypass actor list can push directly while still enforcing the PR requirement for human contributors.

## What changed

- **\`.github/workflows/release.yml\`** — adds \`actions/create-github-app-token@v1\` as the first step to exchange \`RELEASE_BOT_ID\` + \`RELEASE_BOT_PRIVATE_KEY\` org secrets for an installation token
- Passes the app token to \`actions/checkout\` so all subsequent git operations (including the \`@semantic-release/git\` push) run under the app's identity
- Uses the app token as \`GITHUB_TOKEN\` and \`NODE_AUTH_TOKEN\` for the \`Run semantic-release\` step
- npm and Maven publish steps keep \`secrets.GITHUB_TOKEN\` — they need the workflow's \`packages: write\` permission, which the app token doesn't carry
- **\`CLAUDE.md\`** — updated architecture notes to reflect the app token and corrected the plugin order description
- **\`CHANGELOG.md\`** — added entry for the GitHub App token fix

## How to verify

1. Confirm org secrets \`RELEASE_BOT_ID\` and \`RELEASE_BOT_PRIVATE_KEY\` are set and accessible to this repo
2. Confirm the GitHub App is in the \`main\` Ruleset bypass actor list (repo Settings → Rules → Rulesets)
3. Merge this PR, then merge any conventional commit to \`main\`
4. Watch the Release workflow — the \`Run semantic-release\` step should complete without a 403
5. A \`chore(release): x.y.z [skip ci]\` commit should appear on \`main\` and a GitHub Release should be created

## Notes

The IDE warnings about \`RELEASE_BOT_ID\` and \`RELEASE_BOT_PRIVATE_KEY\` are false positives — the Actions linter can't inspect org secrets at design time.