### PR TITLE
Fix: migrate org to budget-buddy-org and fix TS publish in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           node-version: "24"
           registry-url: "https://npm.pkg.github.com"
-          scope: "@glebremniov"
+          scope: "@budget-buddy-org"
           cache: "pnpm"
 
       - uses: actions/setup-java@v5
@@ -76,6 +76,11 @@ jobs:
             generated/typescript/tsconfig.esm.json > /tmp/tsconfig.esm.json
           mv /tmp/tsconfig.esm.json generated/typescript/tsconfig.esm.json
 
+      - name: Install TypeScript package dependencies
+        if: steps.detect.outputs.released == 'true'
+        working-directory: generated/typescript
+        run: pnpm install --no-frozen-lockfile
+
       - name: Publish TypeScript package
         if: steps.detect.outputs.released == 'true'
         working-directory: generated/typescript
@@ -108,6 +113,6 @@ jobs:
         working-directory: generated/java
         run: |
           mvn deploy \
-            -DaltDeploymentRepository="github::https://maven.pkg.github.com/glebremniov/budget-buddy-contracts" \
+            -DaltDeploymentRepository="github::https://maven.pkg.github.com/budget-buddy-org/budget-buddy-contracts" \
             --no-transfer-progress \
             -DskipTests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Install TypeScript package dependencies
         if: steps.detect.outputs.released == 'true'
         working-directory: generated/typescript
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --no-frozen-lockfile  # generated package.json has no lockfile
 
       - name: Publish TypeScript package
         if: steps.detect.outputs.released == 'true'

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Budget Buddy Contracts 🚀
 
 [![OpenAPI Spec](https://img.shields.io/badge/OpenAPI-3.1.0-green.svg)](https://www.openapis.org/)
-[![GitHub Release](https://img.shields.io/github/v/release/glebremniov/budget-buddy-contracts)](https://github.com/glebremniov/budget-buddy-contracts/releases)
-[![npm (GitHub Packages)](https://img.shields.io/badge/npm-pkg.github.com-blue.svg)](https://github.com/glebremniov/budget-buddy-contracts/packages)
-[![Maven (GitHub Packages)](https://img.shields.io/badge/maven-pkg.github.com-blue.svg)](https://github.com/glebremniov/budget-buddy-contracts/packages)
+[![GitHub Release](https://img.shields.io/github/v/release/budget-buddy-org/budget-buddy-contracts)](https://github.com/budget-buddy-org/budget-buddy-contracts/releases)
+[![npm (GitHub Packages)](https://img.shields.io/badge/npm-pkg.github.com-blue.svg)](https://github.com/budget-buddy-org/budget-buddy-contracts/packages)
+[![Maven (GitHub Packages)](https://img.shields.io/badge/maven-pkg.github.com-blue.svg)](https://github.com/budget-buddy-org/budget-buddy-contracts/packages)
 [![Linting: Spectral](https://img.shields.io/badge/linting-spectral-blue.svg)](https://stoplight.io/open-source/spectral)
 [![Validation: OpenAPI Generator](https://img.shields.io/badge/validation-openapi--generator-orange.svg)](https://openapi-generator.tech/)
 [![Swift Package Manager](https://img.shields.io/badge/SPM-compatible-brightgreen.svg)](https://swift.org/package-manager/)
@@ -60,14 +60,14 @@ pnpm install
 Add this repository as a dependency in your `Package.swift`:
 ```swift
 dependencies: [
-    .package(url: "https://github.com/glebremniov/budget-buddy-contracts.git", from: "1.1.0")
+    .package(url: "https://github.com/budget-buddy-org/budget-buddy-contracts.git", from: "1.1.0")
 ]
 ```
 
 ### TypeScript (Web)
 Install from GitHub Packages (requires `.npmrc` configuration):
 ```bash
-pnpm add @glebremniov/budget-buddy-contracts
+pnpm add @budget-buddy-org/budget-buddy-contracts
 ```
 
 ### Java (Spring Boot)

--- a/config/typescript-axios.yaml
+++ b/config/typescript-axios.yaml
@@ -1,7 +1,7 @@
 # openapi-generator config for typescript-axios
 # Consumers: web clients (React, etc.)
-# Published to GitHub Packages as @glebremniov/budget-buddy-contracts
-npmName: "@glebremniov/budget-buddy-contracts"
+# Published to GitHub Packages as @budget-buddy-org/budget-buddy-contracts
+npmName: "@budget-buddy-org/budget-buddy-contracts"
 # npmVersion is intentionally absent — CI injects it from the git tag;
 # local generation (npm run generate:ts) injects it from package.json version.
 supportsES6: true

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@glebremniov/budget-buddy-contracts",
+  "name": "@budget-buddy-org/budget-buddy-contracts",
   "version": "1.2.0",
   "description": "API-first contracts for Budget Buddy — OpenAPI spec + generated clients",
   "private": true,

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -6,7 +6,7 @@ info:
   version: "1.2.0"
   contact:
     name: Budget Buddy
-    url: https://github.com/glebremniov/budget-buddy-contracts
+    url: https://github.com/budget-buddy-org/budget-buddy-contracts
 
 servers:
   - url: "{scheme}://{host}"


### PR DESCRIPTION
## Why

The repository was transferred to the `budget-buddy-org` GitHub organisation, leaving all hardcoded `glebremniov` references broken. A separate CI failure was also discovered in the same release run: the TypeScript publish step was failing because `axios` was not installed before `tsc` ran.

## What changed

- **Org rename** — replaced every `glebremniov` reference with `budget-buddy-org` across `package.json`, `config/typescript-axios.yaml`, `specs/openapi.yaml`, `README.md`, and the release workflow (npm scope + Maven deployment URL)
- **CI fix** — added a `pnpm install --no-frozen-lockfile` step in `generated/typescript/` before `pnpm publish`. The openapi-generator produces a `package.json` but never installs `node_modules`, so the `prepare → tsc` build was failing with `TS2307: Cannot find module 'axios'` on every release

## How to verify

1. Merge and watch the release workflow run — "Install TypeScript package dependencies" should pass, followed by "Publish TypeScript package" completing without `TS2307` errors
2. Confirm the new package version is published under `@budget-buddy-org/budget-buddy-contracts` in GitHub Packages
3. Check badge URLs and SPM package URL in README render correctly pointing to the new org