### PR TITLE
fix(ci): harden release pipeline and fix npm publish auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         id: app-token
         with:
           app-id: ${{ secrets.RELEASE_BOT_ID }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,6 +6,8 @@ on:
       - "specs/**"
       - "config/**"
       - ".spectral.yaml"
+      - "openapi-ts.config.ts"
+      - "openapitools.json"
 
 permissions:
   contents: read

--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -13,18 +13,29 @@ module.exports = {
       },
     ],
     // Updates openapi.yaml version + regenerates Swift sources (prepare phase)
-    // Generates + publishes TypeScript and Java packages (publish phase)
     [
       "@semantic-release/exec",
       {
         prepareCmd:
           "sed -i 's/^  version: .*/  version: \"${nextRelease.version}\"/' specs/openapi.yaml && pnpm run generate:swift",
+      },
+    ],
+    // Publishes TypeScript package to GitHub Packages (npm)
+    [
+      "@semantic-release/exec",
+      {
         publishCmd: [
-          // TypeScript: generate, stamp version, publish to GitHub Packages (npm)
           "pnpm run generate:ts",
           "jq --arg v '${nextRelease.version}' '.version = $v' config/typescript-package.json > generated/typescript/package.json",
-          "(cd generated/typescript && pnpm publish --no-git-checks)",
-          // Java: generate, publish to GitHub Packages (Maven)
+          "pnpm publish --directory generated/typescript --no-git-checks",
+        ].join(" && "),
+      },
+    ],
+    // Publishes Java package to GitHub Packages (Maven)
+    [
+      "@semantic-release/exec",
+      {
+        publishCmd: [
           "pnpm run generate:java",
           "mvn deploy --file generated/java/pom.xml -s config/maven-settings.xml -DaltDeploymentRepository=github::https://maven.pkg.github.com/budget-buddy-org/budget-buddy-contracts --no-transfer-progress -DskipTests",
         ].join(" && "),

--- a/config/typescript-package.json
+++ b/config/typescript-package.json
@@ -12,5 +12,8 @@
     "url": "https://github.com/budget-buddy-org/budget-buddy-contracts.git"
   },
   "sideEffects": false,
-  "license": "MIT"
+  "license": "MIT",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
   "description": "API-first contracts for Budget Buddy — OpenAPI spec + generated clients",
   "private": true,
   "type": "module",
-  "exports": {
-    ".": "./generated/typescript/index.ts"
-  },
   "scripts": {
     "prepare": "husky",
     "commitlint": "commitlint --edit",


### PR DESCRIPTION
## Why

The release pipeline was failing with a 403 when publishing the TypeScript package because `cd generated/typescript && pnpm publish` moved out of the workspace root, leaving npm without the `.npmrc` auth token written by `actions/setup-node`. A broader review uncovered four additional gaps: no self-declared registry in the TS package, TS and Java publish chained in a single failure domain, missing path triggers in the validate workflow, and a floating tag on the one action that mints a privileged token.

## What changed

- **Fix npm publish auth** — replaced `(cd generated/typescript && pnpm publish)` with `pnpm publish --directory generated/typescript` so the workspace-root `.npmrc` is always discovered; added `publishConfig.registry` to `config/typescript-package.json` so the package declares its own target registry
- **Split TS and Java publish into separate exec plugins** — semantic-release tracks each plugin independently, so a Java failure on retry won't attempt to re-publish the already-succeeded TS package (which would 409)
- **Expand validate workflow path filter** — added `openapi-ts.config.ts` and `openapitools.json` so generator version bumps and TS config changes trigger lint + validate on PRs
- **SHA-pin `actions/create-github-app-token`** — the only action that mints a token with push access to the protected branch is now pinned to a commit SHA; version tag kept as a comment
- **Remove dead root package export** — dropped the `exports` field pointing to `./generated/typescript/index.ts`, a gitignored path that never exists at runtime

## How to verify

- Merge to `main` and confirm the release workflow passes all steps, including the TypeScript publish to `https://npm.pkg.github.com`
- Open a test PR that touches `openapi-ts.config.ts` or `openapitools.json` and confirm the Validate workflow is triggered
- Check that `config/typescript-package.json` now contains `publishConfig.registry`
- Confirm `.github/workflows/release.yml` references the SHA rather than the floating `v1` tag for `create-github-app-token`