### PR TITLE
fix: harden CI workflows and add generation smoke tests

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh api:*)",
+      "Bash(wait)"
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(gh api:*)",
-      "Bash(wait)"
-    ]
-  }
-}

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -10,15 +10,15 @@ jobs:
   commitlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
         with:
           version: 10
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "24"
           cache: "pnpm"
@@ -27,3 +27,6 @@ jobs:
 
       - name: Lint commit messages
         run: pnpm exec commitlint --from "${{ github.event.pull_request.base.sha }}" --to "${{ github.event.pull_request.head.sha }}" --verbose
+
+      - name: Lint PR title
+        run: echo "${{ github.event.pull_request.title }}" | pnpm exec commitlint --verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         id: app-token
@@ -21,26 +22,27 @@ jobs:
           app-id: ${{ secrets.RELEASE_BOT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
         with:
           version: 10
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "24"
           registry-url: "https://npm.pkg.github.com"
           scope: "@budget-buddy-org"
           cache: "pnpm"
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: "25"
           distribution: "temurin"
+          cache: "maven"
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,16 +16,22 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
         with:
           version: 10
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "24"
           cache: "pnpm"
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          java-version: "25"
+          distribution: "temurin"
+          cache: "maven"
 
       - run: pnpm install --frozen-lockfile
 
@@ -34,3 +40,9 @@ jobs:
 
       - name: Validate spec
         run: pnpm run validate
+
+      - name: Smoke-test TypeScript generation
+        run: pnpm run generate:ts
+
+      - name: Smoke-test Java generation
+        run: pnpm run generate:java

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ node_modules
 
 # Husky runtime files are created by `npm install` and should stay local.
 .husky/_/
+
+# Claude Code local settings
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ Releases are fully automated via semantic-release on push to `main`.
 
 1. Edit `specs/openapi.yaml` (and/or `config/*.yaml`)
 2. `pnpm run lint && pnpm run validate`
-3. Commit with a conventional commit message (`feat:`, `fix:`, `feat!:`, etc.) and merge to `main`
+3. Open a PR with a conventional commit title (`feat:`, `fix:`, `feat!:`, etc.) — the PR title becomes the merge commit because PRs are squash-merged
 4. CI does the rest:
    - determines next version from commit history
    - bumps `package.json` on disk (used by generation scripts)
@@ -63,6 +63,8 @@ Releases are fully automated via semantic-release on push to `main`.
    - generates and publishes TypeScript (npm) and Java (Maven) to GitHub Packages
 
 Do **not** manually bump versions, tag, or run `generate:swift` before merging — semantic-release owns all of that.
+
+> **Squash-merge convention:** always use squash merge on GitHub. The PR title is what lands on `main` and what semantic-release reads to determine the next version. Individual commit messages within the PR are validated by CI but do not affect versioning.
 
 
 ## Architecture
@@ -75,9 +77,10 @@ Do **not** manually bump versions, tag, or run `generate:swift` before merging �
 - `openapitools.json` — pins openapi-generator version (currently 7.21.0; needed for OAS 3.1 `type: [string, "null"]`)
 - `Package.swift` — makes this repo a valid Swift Package; points to `Sources/BudgetBuddyContracts/`
 - `.spectral.yaml` — enforces `operationId` on every operation (error) and tags (warn); generators rely on both
-- `.github/workflows/validate.yml` — runs lint + validate on PRs that touch `specs/` or `config/`
-- `.github/workflows/release.yml` — on push to `main`: generates a GitHub App token (`RELEASE_BOT_ID` + `RELEASE_BOT_PRIVATE_KEY` org secrets) to bypass the branch ruleset PR requirement, then runs semantic-release and publishes TypeScript (npm) + Java (Maven) to GitHub Packages
-- `.releaserc.cjs` — semantic-release plugin config; plugin order matters (changelog → npm → exec/swift → git commit → github)
+- `.github/workflows/commitlint.yml` — runs on every PR: validates individual commit messages and the PR title against conventional commit rules (PR title is what lands on `main` via squash merge)
+- `.github/workflows/validate.yml` — runs on PRs touching `specs/`, `config/`, `.spectral.yaml`, `openapi-ts.config.ts`, or `openapitools.json`: lints the spec, validates its structure, and smoke-tests TypeScript and Java generation
+- `.github/workflows/release.yml` — on push to `main`: generates a GitHub App token (`RELEASE_BOT_ID` + `RELEASE_BOT_PRIVATE_KEY` org secrets) to bypass the branch ruleset PR requirement, then runs semantic-release and publishes TypeScript (npm) + Java (Maven) to GitHub Packages; has a 20-minute timeout
+- `.releaserc.cjs` — semantic-release plugin config; plugin order matters: changelog → npm (version bump) → exec/swift prepare → exec/typescript publish → exec/java publish → git commit → github release
 
 ## Spec conventions
 


### PR DESCRIPTION
## Why

Several gaps remained after the release pipeline fix: PR titles were never validated as conventional commits (critical since PRs are squash-merged and the title becomes the merge commit that semantic-release reads), broken generator configs would only fail at release time, Maven deps were re-downloaded on every run, and all action tags except `create-github-app-token` were left as floating major-version refs.

## What changed

- **PR title linting** — `commitlint.yml` now validates the PR title in addition to individual commit messages; the title is what lands on `main` via squash merge and drives semantic-release versioning
- **Generation smoke tests** — `validate.yml` now runs `generate:ts` and `generate:java` on PRs, catching broken `openapi-ts.config.ts` or `spring-server.yaml` before they reach the release job; `setup-java` with Maven cache added to support the Java step
- **Maven caching** — `cache: "maven"` enabled on `setup-java` in both `release.yml` and `validate.yml`
- **Job timeout** — `timeout-minutes: 20` added to the release job to bound runaway Maven deploys
- **SHA-pin all action tags** — `checkout`, `pnpm/action-setup`, `setup-node`, and `setup-java` pinned to commit SHAs across all three workflows
- **Untrack `.claude/`** — added `.claude/` to `.gitignore`; Claude Code's local settings file was accidentally staged
- **CLAUDE.md** — updated to reflect squash-merge convention, extended validate triggers, commitlint workflow, and current releaserc plugin order

## How to verify

- Open a PR with a non-conventional title (e.g. "update stuff") — the Commitlint workflow should fail on "Lint PR title"
- Open a PR touching `openapi-ts.config.ts` — the Validate workflow should run the generation smoke-test steps
- Merge to `main` and confirm a patch release is cut and the release job completes well under 20 minutes
- Check all `uses:` lines reference commit SHAs rather than floating tags