### PR TITLE
fix: remove maven cache from setup-java

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,6 @@ jobs:
         with:
           java-version: "25"
           distribution: "temurin"
-          cache: "maven"
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -31,7 +31,6 @@ jobs:
         with:
           java-version: "25"
           distribution: "temurin"
-          cache: "maven"
 
       - run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Why

The release (and validate) job started failing immediately after the CI hardening PR merged:

```
Error: No file in /home/runner/work/budget-buddy-contracts/budget-buddy-contracts
matched to [**/pom.xml], make sure you have checked out the target repository
```

`setup-java`'s `cache: "maven"` looks for `pom.xml` at job startup to fingerprint the cache key. But `pom.xml` is generated by `generate:java` during the run and lives in `generated/java/` — which is gitignored. There is no committed `pom.xml` for it to find.

## What changed

- Removed `cache: "maven"` from `setup-java` in both `release.yml` and `validate.yml`

## Notes

Maven caching via `setup-java` requires a `pom.xml` committed to the repo. Since ours is an ephemeral generated artifact, this feature is not usable here. Maven dependency downloads are fast enough that the missing cache is not a meaningful regression.