### PR TITLE
fix: use positional dir arg in pnpm publish

### DIFF
--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -27,7 +27,7 @@ module.exports = {
         publishCmd: [
           "pnpm run generate:ts",
           "jq --arg v '${nextRelease.version}' '.version = $v' config/typescript-package.json > generated/typescript/package.json",
-          "pnpm publish --directory generated/typescript --no-git-checks",
+          "pnpm publish generated/typescript --no-git-checks",
         ].join(" && "),
       },
     ],


### PR DESCRIPTION
## Why

`pnpm publish` does not accept a `--directory` flag. The target directory is a positional argument (`pnpm publish [<tarball>|<dir>]`). Using `--directory` caused every release to fail with `Unknown option: 'directory'` immediately after TypeScript generation succeeded.

## What changed

- `.releaserc.cjs`: `pnpm publish --directory generated/typescript` → `pnpm publish generated/typescript`

## How to verify

- Merge this PR — the release workflow should complete the TypeScript publish step without error
- Locally: `pnpm run generate:ts && jq --arg v '1.3.1' '.version = $v' config/typescript-package.json > generated/typescript/package.json && pnpm publish generated/typescript --dry-run --no-git-checks` — should list package contents with no error