### PR TITLE
fix: use workflow token for package publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Run semantic-release
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          NODE_AUTH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+          NODE_AUTH_TOKEN: ${{ github.token }}
         run: pnpm exec semantic-release
 


### PR DESCRIPTION
## Why

The GitHub App token (`RELEASE_BOT_ID`) is an organization-level installation token. GitHub App installations require explicit `packages:write` permission to be granted in the App's settings — ours doesn't have it, which caused every release to fail with:

```
403 Forbidden - permission_denied: installation not allowed to Write organization package
```

The fix was hiding behind the previous `pnpm publish --directory` syntax error (PR #41). Once that was resolved, the auth failure became visible.

## What changed

- `release.yml`: `GITHUB_TOKEN` and `NODE_AUTH_TOKEN` now use `${{ github.token }}` (the workflow token) instead of the App token

The workflow-level `permissions: packages: write` block already grants the workflow token write access to GitHub Packages — both npm and Maven.

## Why git push to protected main still works

`actions/checkout` with `token: ${{ steps.app-token.outputs.token }}` stores the App token as git credentials in git config. When `@semantic-release/git` runs `git push`, git uses those stored credentials — not the `GITHUB_TOKEN` env var. The two are independent, so branch protection bypass is unaffected.

## How to verify

Merge this PR and confirm the release workflow completes the publish steps for both TypeScript (npm) and Java (Maven) without a 403.