### PR TITLE
fix: resolve publish auth by splitting release and publish workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,98 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or branch to publish from (e.g. v1.2.3)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish-typescript:
+    name: Publish TypeScript
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
+        with:
+          version: 10
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: "24"
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@budget-buddy-org"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from package.json
+        id: version
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
+      - name: Generate TypeScript client
+        run: pnpm run generate:ts
+
+      - name: Inject version into package manifest
+        run: |
+          jq --arg v "${{ steps.version.outputs.version }}" '.version = $v' \
+            config/typescript-package.json > generated/typescript/package.json
+
+      - name: Publish to GitHub Packages (npm)
+        run: pnpm publish generated/typescript --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-java:
+    name: Publish Java
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
+        with:
+          version: 10
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          java-version: "25"
+          distribution: "temurin"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate Java client
+        run: pnpm run generate:java
+
+      - name: Publish to GitHub Packages (Maven)
+        run: >-
+          mvn deploy
+          --file generated/java/pom.xml
+          -s config/maven-settings.xml
+          -DaltDeploymentRepository=github::https://maven.pkg.github.com/budget-buddy-org/budget-buddy-contracts
+          --no-transfer-progress
+          -DskipTests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
-  packages: write
 
 jobs:
   release:
@@ -34,8 +33,6 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "24"
-          registry-url: "https://npm.pkg.github.com"
-          scope: "@budget-buddy-org"
           cache: "pnpm"
 
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
@@ -48,6 +45,4 @@ jobs:
       - name: Run semantic-release
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          NODE_AUTH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: pnpm exec semantic-release
-

--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -20,27 +20,6 @@ module.exports = {
           "sed -i 's/^  version: .*/  version: \"${nextRelease.version}\"/' specs/openapi.yaml && pnpm run generate:swift",
       },
     ],
-    // Publishes TypeScript package to GitHub Packages (npm)
-    [
-      "@semantic-release/exec",
-      {
-        publishCmd: [
-          "pnpm run generate:ts",
-          "jq --arg v '${nextRelease.version}' '.version = $v' config/typescript-package.json > generated/typescript/package.json",
-          "pnpm publish generated/typescript --no-git-checks",
-        ].join(" && "),
-      },
-    ],
-    // Publishes Java package to GitHub Packages (Maven)
-    [
-      "@semantic-release/exec",
-      {
-        publishCmd: [
-          "pnpm run generate:java",
-          "mvn deploy --file generated/java/pom.xml -s config/maven-settings.xml -DaltDeploymentRepository=github::https://maven.pkg.github.com/budget-buddy-org/budget-buddy-contracts --no-transfer-progress -DskipTests",
-        ].join(" && "),
-      },
-    ],
     // Commits all prepare-phase changes (CHANGELOG, package.json, spec, Swift sources)
     [
       "@semantic-release/git",
@@ -55,7 +34,7 @@ module.exports = {
           "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
       },
     ],
-    // Creates GitHub Release with notes
+    // Creates GitHub Release — triggers the Publish workflow
     "@semantic-release/github",
   ],
 };

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,10 +57,10 @@ Releases are fully automated via semantic-release on push to `main`.
 3. Open a PR with a conventional commit title (`feat:`, `fix:`, `feat!:`, etc.) — the PR title becomes the merge commit because PRs are squash-merged
 4. CI does the rest:
    - determines next version from commit history
-   - bumps `package.json` on disk (used by generation scripts)
-   - regenerates Swift sources
+   - bumps `package.json` and `specs/openapi.yaml` version on disk
+   - regenerates Swift sources and commits them
    - creates the git tag and GitHub Release
-   - generates and publishes TypeScript (npm) and Java (Maven) to GitHub Packages
+   - the GitHub Release triggers the Publish workflow, which generates and publishes TypeScript (npm) and Java (Maven) to GitHub Packages in parallel
 
 Do **not** manually bump versions, tag, or run `generate:swift` before merging — semantic-release owns all of that.
 
@@ -79,8 +79,9 @@ Do **not** manually bump versions, tag, or run `generate:swift` before merging �
 - `.spectral.yaml` — enforces `operationId` on every operation (error) and tags (warn); generators rely on both
 - `.github/workflows/commitlint.yml` — runs on every PR: validates individual commit messages and the PR title against conventional commit rules (PR title is what lands on `main` via squash merge)
 - `.github/workflows/validate.yml` — runs on PRs touching `specs/`, `config/`, `.spectral.yaml`, `openapi-ts.config.ts`, or `openapitools.json`: lints the spec, validates its structure, and smoke-tests TypeScript and Java generation
-- `.github/workflows/release.yml` — on push to `main`: generates a GitHub App token (`RELEASE_BOT_ID` + `RELEASE_BOT_PRIVATE_KEY` org secrets) to bypass the branch ruleset PR requirement, then runs semantic-release and publishes TypeScript (npm) + Java (Maven) to GitHub Packages; has a 20-minute timeout
-- `.releaserc.cjs` — semantic-release plugin config; plugin order matters: changelog → npm (version bump) → exec/swift prepare → exec/typescript publish → exec/java publish → git commit → github release
+- `.github/workflows/release.yml` — on push to `main`: generates a GitHub App token (`RELEASE_BOT_ID` + `RELEASE_BOT_PRIVATE_KEY` org secrets) to bypass the branch ruleset PR requirement, then runs semantic-release; has a 20-minute timeout
+- `.github/workflows/publish.yml` — triggered by `release: published`: generates and publishes TypeScript (npm) and Java (Maven) to GitHub Packages in two parallel jobs; also supports `workflow_dispatch` for manual retries; uses the workflow token (`GITHUB_TOKEN`) which has `packages: write`
+- `.releaserc.cjs` — semantic-release plugin config; plugin order matters: changelog → npm (version bump only, no publish) → exec/swift prepare → git commit → github release (which triggers the Publish workflow)
 
 ## Spec conventions
 


### PR DESCRIPTION
## Why

Publishing inside semantic-release requires the token that runs the release to also have `packages: write`. But the App token (needed to bypass branch protection and push the release commit to `main`) doesn't have `packages: write` on the org installation — and fixing that would require a GitHub App settings change.

The workflow token (`GITHUB_TOKEN`) already has `packages: write` via the `permissions:` block, but it can't push to the protected branch. No single token can do both.

This is the same problem solved in `budget-buddy-web-app` by splitting `ci.yml` (releases) and `publish.yml` (Docker image push). This PR applies the same pattern here.

## What changed

**`release.yml`** — semantic-release only, no publishing
- Removed `packages: write` permission (not needed)
- Removed `registry-url`, `scope`, `NODE_AUTH_TOKEN` from setup-node (not publishing npm here)
- `GITHUB_TOKEN` stays as the App token for git push + GitHub release creation

**`publish.yml`** — new, triggered by `release: published`
- Two **parallel** jobs: `publish-typescript` and `publish-java`
- Both use `${{ secrets.GITHUB_TOKEN }}` (workflow token with `packages: write`)
- Reads version from `package.json` at the release tag — no token juggling
- `workflow_dispatch` input lets you re-run against any tag without re-triggering semantic-release

**`.releaserc.cjs`** — removed TypeScript and Java publish exec plugins; release now ends with `@semantic-release/github` creating the release (which fires the publish workflow)

**`CLAUDE.md`** — updated to describe the two-workflow architecture

## How to verify

1. Merge this PR — the next push to `main` that triggers a release should:
   - Complete `release.yml` (semantic-release creates the GitHub Release)
   - Automatically trigger `publish.yml` (two parallel jobs publish to npm and Maven)
2. Check the Actions tab: two separate workflow runs, parallel publish jobs both green
3. Confirm the TypeScript package appears in GitHub Packages (npm) and the Java package in GitHub Packages (Maven)

## Notes

Supersedes PR #41 and PR #42 which were incremental fixes to the monolithic approach. This resolves the root cause instead of patching around it.