### PR TITLE
fix: explicitly set GITHUB_TOKEN env for Maven publish step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,98 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or branch to publish from (e.g. v1.2.3)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish-typescript:
+    name: Publish TypeScript
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
+        with:
+          version: 10
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: "24"
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@budget-buddy-org"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from package.json
+        id: version
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
+      - name: Generate TypeScript client
+        run: pnpm run generate:ts
+
+      - name: Inject version into package manifest
+        run: |
+          jq --arg v "${{ steps.version.outputs.version }}" '.version = $v' \
+            config/typescript-package.json > generated/typescript/package.json
+
+      - name: Publish to GitHub Packages (npm)
+        run: pnpm publish generated/typescript --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-java:
+    name: Publish Java
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
+        with:
+          version: 10
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          java-version: "25"
+          distribution: "temurin"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate Java client
+        run: pnpm run generate:java
+
+      - name: Publish to GitHub Packages (Maven)
+        run: >-
+          mvn deploy
+          --file generated/java/pom.xml
+          -s config/maven-settings.xml
+          -DaltDeploymentRepository=github::https://maven.pkg.github.com/budget-buddy-org/budget-buddy-contracts
+          --no-transfer-progress
+          -DskipTests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,3 +96,5 @@ jobs:
           -DaltDeploymentRepository=github::https://maven.pkg.github.com/budget-buddy-org/budget-buddy-contracts
           --no-transfer-progress
           -DskipTests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
-  packages: write
 
 jobs:
   release:
@@ -34,8 +33,6 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "24"
-          registry-url: "https://npm.pkg.github.com"
-          scope: "@budget-buddy-org"
           cache: "pnpm"
 
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
@@ -48,6 +45,4 @@ jobs:
       - name: Run semantic-release
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          NODE_AUTH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: pnpm exec semantic-release
-

--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -20,27 +20,6 @@ module.exports = {
           "sed -i 's/^  version: .*/  version: \"${nextRelease.version}\"/' specs/openapi.yaml && pnpm run generate:swift",
       },
     ],
-    // Publishes TypeScript package to GitHub Packages (npm)
-    [
-      "@semantic-release/exec",
-      {
-        publishCmd: [
-          "pnpm run generate:ts",
-          "jq --arg v '${nextRelease.version}' '.version = $v' config/typescript-package.json > generated/typescript/package.json",
-          "pnpm publish generated/typescript --no-git-checks",
-        ].join(" && "),
-      },
-    ],
-    // Publishes Java package to GitHub Packages (Maven)
-    [
-      "@semantic-release/exec",
-      {
-        publishCmd: [
-          "pnpm run generate:java",
-          "mvn deploy --file generated/java/pom.xml -s config/maven-settings.xml -DaltDeploymentRepository=github::https://maven.pkg.github.com/budget-buddy-org/budget-buddy-contracts --no-transfer-progress -DskipTests",
-        ].join(" && "),
-      },
-    ],
     // Commits all prepare-phase changes (CHANGELOG, package.json, spec, Swift sources)
     [
       "@semantic-release/git",
@@ -55,7 +34,7 @@ module.exports = {
           "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
       },
     ],
-    // Creates GitHub Release with notes
+    // Creates GitHub Release — triggers the Publish workflow
     "@semantic-release/github",
   ],
 };

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,10 +57,10 @@ Releases are fully automated via semantic-release on push to `main`.
 3. Open a PR with a conventional commit title (`feat:`, `fix:`, `feat!:`, etc.) — the PR title becomes the merge commit because PRs are squash-merged
 4. CI does the rest:
    - determines next version from commit history
-   - bumps `package.json` on disk (used by generation scripts)
-   - regenerates Swift sources
+   - bumps `package.json` and `specs/openapi.yaml` version on disk
+   - regenerates Swift sources and commits them
    - creates the git tag and GitHub Release
-   - generates and publishes TypeScript (npm) and Java (Maven) to GitHub Packages
+   - the GitHub Release triggers the Publish workflow, which generates and publishes TypeScript (npm) and Java (Maven) to GitHub Packages in parallel
 
 Do **not** manually bump versions, tag, or run `generate:swift` before merging — semantic-release owns all of that.
 
@@ -79,8 +79,9 @@ Do **not** manually bump versions, tag, or run `generate:swift` before merging �
 - `.spectral.yaml` — enforces `operationId` on every operation (error) and tags (warn); generators rely on both
 - `.github/workflows/commitlint.yml` — runs on every PR: validates individual commit messages and the PR title against conventional commit rules (PR title is what lands on `main` via squash merge)
 - `.github/workflows/validate.yml` — runs on PRs touching `specs/`, `config/`, `.spectral.yaml`, `openapi-ts.config.ts`, or `openapitools.json`: lints the spec, validates its structure, and smoke-tests TypeScript and Java generation
-- `.github/workflows/release.yml` — on push to `main`: generates a GitHub App token (`RELEASE_BOT_ID` + `RELEASE_BOT_PRIVATE_KEY` org secrets) to bypass the branch ruleset PR requirement, then runs semantic-release and publishes TypeScript (npm) + Java (Maven) to GitHub Packages; has a 20-minute timeout
-- `.releaserc.cjs` — semantic-release plugin config; plugin order matters: changelog → npm (version bump) → exec/swift prepare → exec/typescript publish → exec/java publish → git commit → github release
+- `.github/workflows/release.yml` — on push to `main`: generates a GitHub App token (`RELEASE_BOT_ID` + `RELEASE_BOT_PRIVATE_KEY` org secrets) to bypass the branch ruleset PR requirement, then runs semantic-release; has a 20-minute timeout
+- `.github/workflows/publish.yml` — triggered by `release: published`: generates and publishes TypeScript (npm) and Java (Maven) to GitHub Packages in two parallel jobs; also supports `workflow_dispatch` for manual retries; uses the workflow token (`GITHUB_TOKEN`) which has `packages: write`
+- `.releaserc.cjs` — semantic-release plugin config; plugin order matters: changelog → npm (version bump only, no publish) → exec/swift prepare → git commit → github release (which triggers the Publish workflow)
 
 ## Spec conventions
 


### PR DESCRIPTION
## Why

The Maven publish step was getting `401 Unauthorized` from GitHub Packages. `maven-settings.xml` reads credentials via `${env.GITHUB_TOKEN}`, but GitHub Actions only guarantees `GITHUB_TOKEN` is in a step's environment when it is explicitly mapped in the step's `env:` block. Without it, the variable is absent and Maven sends no credentials.

The TypeScript publish job was unaffected because `actions/setup-node` writes `NODE_AUTH_TOKEN` directly into `.npmrc` — a different mechanism.

## What changed

- `publish.yml`: added `env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the Maven publish step

## How to verify

Trigger `workflow_dispatch` on the Publish workflow against `v1.3.3`. The Java job should now fail with a version-already-exists error (409/422) rather than 401 — confirming auth works.