### PR TITLE
fix: explicitly set GITHUB_TOKEN env for Maven publish step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,3 +96,5 @@ jobs:
           -DaltDeploymentRepository=github::https://maven.pkg.github.com/budget-buddy-org/budget-buddy-contracts
           --no-transfer-progress
           -DskipTests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why

The Maven publish step was getting `401 Unauthorized` from GitHub Packages. `maven-settings.xml` reads credentials via `${env.GITHUB_TOKEN}`, but GitHub Actions only guarantees `GITHUB_TOKEN` is in a step's environment when it is explicitly mapped in the step's `env:` block. Without it, the variable is absent and Maven sends no credentials.

The TypeScript publish job was unaffected because `actions/setup-node` writes `NODE_AUTH_TOKEN` directly into `.npmrc` — a different mechanism.

## What changed

- `publish.yml`: added `env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the Maven publish step

## How to verify

Trigger `workflow_dispatch` on the Publish workflow against `v1.3.3`. The Java job should now fail with a version-already-exists error (409/422) rather than 401 — confirming auth works.