### PR TITLE
feat(spec): documentation & quality

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -5,3 +5,21 @@ rules:
   # Tags group operations into separate API classes in generated code
   operation-tags: warn
   operation-tag-defined: warn
+  # Tags should describe their purpose for generated API docs
+  tag-description: warn
+  # Every operation must document a 500 response so clients can handle server errors
+  operation-500-response:
+    message: "Operation '{{path}}' is missing a 500 response — all operations should document server error behaviour."
+    severity: warn
+    given: "$.paths[*][get,post,put,patch,delete,options,head,trace]"
+    then:
+      field: "responses.500"
+      function: truthy
+  # Every schema property should have a description for generated client documentation
+  schema-property-description:
+    message: "Property '{{path}}' is missing a description."
+    severity: warn
+    given: "$.components.schemas[*].properties[*]"
+    then:
+      field: description
+      function: truthy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ Do **not** manually bump versions, tag, or run `generate:swift` before merging �
 - `config/maven-settings.xml` — Maven server credentials template; references `${env.GITHUB_ACTOR}` and `${env.GITHUB_TOKEN}` so it is safe to commit (no hardcoded secrets)
 - `openapitools.json` — pins openapi-generator version (currently 7.21.0; needed for OAS 3.1 `type: [string, "null"]`)
 - `Package.swift` — makes this repo a valid Swift Package; points to `Sources/BudgetBuddyContracts/`
-- `.spectral.yaml` — enforces `operationId` on every operation (error) and tags (warn); generators rely on both
+- `.spectral.yaml` — enforces `operationId` on every operation (error), tags (warn), tag descriptions (warn), a 500 response on every operation (warn), and a `description` on every schema property (warn); generators rely on operationId and tags
 - `.github/workflows/commitlint.yml` — runs on every PR: validates individual commit messages and the PR title against conventional commit rules (PR title is what lands on `main` via squash merge)
 - `.github/workflows/validate.yml` — runs on PRs touching `specs/`, `config/`, `.spectral.yaml`, `openapi-ts.config.ts`, or `openapitools.json`: lints the spec, validates its structure, and smoke-tests TypeScript and Java generation
 - `.github/workflows/release.yml` — on push to `main`: generates a GitHub App token (`RELEASE_BOT_ID` + `RELEASE_BOT_PRIVATE_KEY` org secrets) to bypass the branch ruleset PR requirement, then runs semantic-release; has a 20-minute timeout
@@ -86,8 +86,12 @@ Do **not** manually bump versions, tag, or run `generate:swift` before merging �
 ## Spec conventions
 
 - All operations have an `operationId` (required by Spectral, used for generated method names)
+- All operations document a `500` response using the reusable `InternalServerError` component
+- All schema properties have a `description` field (enforced by Spectral)
+- All API tags have a `description` field (enforced by Spectral)
 - Error responses use `application/problem+json` with the `Problem` schema (RFC 9457)
 - Amounts are `integer` in minor currency units (e.g. `1299` = €12.99)
 - Write schemas (POST/PUT body) and Update schemas (PATCH body) are separate from read schemas
 - PATCH schemas represent partial updates: fields are optional, and empty patch objects are invalid
 - Auth endpoints override global security with `security: []`
+- When adding a `description` alongside a `$ref`, use `allOf` wrapping: `allOf: [{$ref: ...}]` with `description` as a sibling — avoids Spectral false positives with bare `$ref` + `description`

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -22,8 +22,11 @@ servers:
 
 tags:
   - name: auth
+    description: Authentication — register, login, refresh, and logout.
   - name: categories
+    description: Manage spending categories for the authenticated user.
   - name: transactions
+    description: Record and query financial transactions for the authenticated user.
 
 security:
   - BearerAuth: [ ]
@@ -51,6 +54,8 @@ paths:
                 $ref: "#/components/schemas/AuthToken"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
   /v1/auth/refresh:
     post:
@@ -74,6 +79,8 @@ paths:
                 $ref: "#/components/schemas/AuthToken"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
   /v1/auth/register:
     post:
@@ -89,12 +96,14 @@ paths:
             schema:
               $ref: "#/components/schemas/RegisterRequest"
       responses:
-        "201":
-          description: User registered successfully
+        "204":
+          description: User created successfully
         "400":
           $ref: "#/components/responses/BadRequest"
         "409":
           $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
   /v1/auth/logout:
     post:
@@ -107,6 +116,8 @@ paths:
           description: Logged out successfully
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
   /v1/categories:
     get:
@@ -126,6 +137,8 @@ paths:
                 $ref: "#/components/schemas/PaginatedCategories"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
     post:
       tags: [ categories ]
@@ -155,6 +168,8 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
   /v1/categories/{categoryId}:
     parameters:
@@ -176,6 +191,8 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
     put:
       tags: [ categories ]
@@ -201,6 +218,8 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
     patch:
       tags: [ categories ]
@@ -226,6 +245,8 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
     delete:
       tags: [ categories ]
@@ -239,6 +260,8 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
   /v1/transactions:
     get:
@@ -285,6 +308,8 @@ paths:
                 $ref: "#/components/schemas/PaginatedTransactions"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
     post:
       tags: [ transactions ]
@@ -314,6 +339,8 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
   /v1/transactions/{transactionId}:
     parameters:
@@ -335,6 +362,8 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
     put:
       tags: [ transactions ]
@@ -360,6 +389,8 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
     patch:
       tags: [ transactions ]
@@ -385,6 +416,8 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
     delete:
       tags: [ transactions ]
@@ -398,6 +431,8 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
 components:
   securitySchemes:
@@ -428,6 +463,7 @@ components:
     limit:
       name: limit
       in: query
+      description: Maximum number of items to return.
       schema:
         type: integer
         minimum: 1
@@ -437,6 +473,7 @@ components:
     offset:
       name: offset
       in: query
+      description: Number of items to skip before returning results.
       schema:
         type: integer
         minimum: 0
@@ -471,6 +508,13 @@ components:
           schema:
             $ref: "#/components/schemas/Problem"
 
+    InternalServerError:
+      description: Unexpected server error
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/Problem"
+
   schemas:
     RegisterRequest:
       type: object
@@ -478,11 +522,13 @@ components:
       properties:
         username:
           type: string
+          description: Unique username chosen by the user (3–50 characters).
           minLength: 3
           maxLength: 50
           example: john
         password:
           type: string
+          description: Account password (minimum 8 characters).
           minLength: 8
           example: strongpassword123
 
@@ -492,9 +538,11 @@ components:
       properties:
         username:
           type: string
+          description: The user's registered username.
           example: john
         password:
           type: string
+          description: The user's account password.
           example: strongpassword123
 
     RefreshTokenRequest:
@@ -512,11 +560,14 @@ components:
       properties:
         access_token:
           type: string
+          description: JWT access token used in the Authorization header for subsequent requests.
         token_type:
           type: string
+          description: Token type, always "Bearer".
           example: Bearer
         expires_in:
           type: integer
+          description: Lifetime of the access token in seconds.
           example: 3600
         refresh_token:
           type: string
@@ -532,16 +583,20 @@ components:
         id:
           type: string
           format: uuid
+          description: Unique identifier for the category.
           example: 550e8400-e29b-41d4-a716-446655440000
         name:
           type: string
+          description: Human-readable name of the category.
           example: Groceries
         createdAt:
           type: string
           format: date-time
+          description: ISO 8601 timestamp when the category was created.
         updatedAt:
           type: string
           format: date-time
+          description: ISO 8601 timestamp when the category was last updated.
 
     CategoryWrite:
       type: object
@@ -549,6 +604,7 @@ components:
       properties:
         name:
           type: string
+          description: Human-readable name for the category (1–255 characters).
           minLength: 1
           maxLength: 255
           example: Restaurants
@@ -560,6 +616,7 @@ components:
       properties:
         name:
           type: string
+          description: New human-readable name for the category (1–255 characters).
           minLength: 1
           maxLength: 255
           example: Dining
@@ -571,37 +628,45 @@ components:
         id:
           type: string
           format: uuid
+          description: Unique identifier for the transaction.
         categoryId:
           type: string
           format: uuid
+          description: UUID of the category this transaction belongs to.
         amount:
           type: integer
           format: int64
-          description: Amount in minor units
+          description: Amount in minor units (e.g. 1299 = €12.99).
           example: 1299
         type:
           type: string
+          description: Whether this transaction is an outgoing expense or incoming income.
           enum:
             - EXPENSE
             - INCOME
         currency:
           type: string
+          description: ISO 4217 three-letter currency code.
           minLength: 3
           maxLength: 3
           example: EUR
         date:
           type: string
           format: date
+          description: Date on which the transaction occurred (YYYY-MM-DD).
           example: 2026-03-08
         description:
           type: string
+          description: Optional free-text note for the transaction.
           example: Coffee
         createdAt:
           type: string
           format: date-time
+          description: ISO 8601 timestamp when the transaction record was created.
         updatedAt:
           type: string
           format: date-time
+          description: ISO 8601 timestamp when the transaction record was last updated.
 
     TransactionWrite:
       type: object
@@ -610,24 +675,30 @@ components:
         categoryId:
           type: string
           format: uuid
+          description: UUID of the category this transaction belongs to.
         amount:
           type: integer
           format: int64
+          description: Amount in minor units (e.g. 1299 = €12.99). Must be at least 1.
           minimum: 1
           example: 1299
         type:
           type: string
+          description: Whether this transaction is an outgoing expense or incoming income.
           enum: [ EXPENSE, INCOME ]
         currency:
           type: string
+          description: ISO 4217 three-letter currency code.
           minLength: 3
           maxLength: 3
           example: EUR
         date:
           type: string
           format: date
+          description: Date on which the transaction occurred (YYYY-MM-DD).
         description:
           type: string
+          description: Optional free-text note for the transaction.
 
     TransactionUpdate:
       type: object
@@ -637,21 +708,27 @@ components:
         categoryId:
           type: string
           format: uuid
+          description: UUID of the category to reassign this transaction to.
         amount:
           type: integer
+          description: New amount in minor units. Must be at least 1.
           minimum: 1
         type:
           type: string
+          description: New transaction type (EXPENSE or INCOME).
           enum: [ EXPENSE, INCOME ]
         currency:
           type: string
+          description: New ISO 4217 three-letter currency code.
           minLength: 3
           maxLength: 3
         date:
           type: string
           format: date
+          description: New transaction date (YYYY-MM-DD).
         description:
           type: [ string, "null" ]
+          description: Updated free-text note. Pass null to clear the existing note.
 
     PaginationMeta:
       type: object
@@ -659,11 +736,14 @@ components:
       properties:
         limit:
           type: integer
+          description: The page size used for this response.
         offset:
           type: integer
+          description: The number of items skipped before this page.
         total:
           type: integer
           format: int64
+          description: Total number of items matching the request across all pages.
 
     PaginatedCategories:
       type: object
@@ -671,10 +751,13 @@ components:
       properties:
         items:
           type: array
+          description: The categories on the current page.
           items:
             $ref: "#/components/schemas/Category"
         meta:
-          $ref: "#/components/schemas/PaginationMeta"
+          description: Pagination metadata for the current response.
+          allOf:
+            - $ref: "#/components/schemas/PaginationMeta"
 
     PaginatedTransactions:
       type: object
@@ -682,10 +765,13 @@ components:
       properties:
         items:
           type: array
+          description: The transactions on the current page.
           items:
             $ref: "#/components/schemas/Transaction"
         meta:
-          $ref: "#/components/schemas/PaginationMeta"
+          description: Pagination metadata for the current response.
+          allOf:
+            - $ref: "#/components/schemas/PaginationMeta"
 
     Problem:
       type: object
@@ -695,13 +781,18 @@ components:
         type:
           type: string
           format: uri
+          description: URI that identifies the problem type. Defaults to "about:blank" when not set.
           default: "about:blank"
         title:
           type: string
+          description: Short, human-readable summary of the problem type.
         status:
           type: integer
+          description: HTTP status code for this occurrence of the problem.
         detail:
           type: string
+          description: Human-readable explanation specific to this occurrence of the problem.
         instance:
           type: string
           format: uri
+          description: URI reference identifying the specific occurrence of the problem.


### PR DESCRIPTION
## Why

Addresses all four sub-issues in budget-buddy-org/budget-buddy-contracts#47 — documentation quality gaps in the OpenAPI spec and Spectral ruleset.

## What changed

- **[specs/openapi.yaml]** Added `description` to all 3 API tags (`auth`, `categories`, `transactions`)
- **[specs/openapi.yaml]** Added `description` to all schema properties that were missing one across `RegisterRequest`, `LoginRequest`, `AuthToken`, `Category`, `CategoryWrite`, `CategoryUpdate`, `Transaction`, `TransactionWrite`, `TransactionUpdate`, `PaginationMeta`, `PaginatedCategories`, `PaginatedTransactions`, and `Problem`
- **[specs/openapi.yaml]** Added `description` to the reusable `limit` and `offset` query parameters
- **[specs/openapi.yaml]** Changed `POST /v1/auth/register` response from `201` (with no body) to `204` — registration creates the account only; clients call `/login` separately
- **[specs/openapi.yaml]** Added `InternalServerError` reusable response component and wired a `500` response to all 16 operations
- **[specs/openapi.yaml]** Switched `PaginatedCategories.meta` and `PaginatedTransactions.meta` to `allOf` + `$ref` pattern to correctly attach descriptions alongside schema references
- **[.spectral.yaml]** Enabled `tag-description: warn`; added `operation-500-response` and `schema-property-description` custom rules
- **[CLAUDE.md]** Updated `.spectral.yaml` description and Spec conventions to reflect the new requirements

## Acceptance criteria

- ✅ `500 Internal Server Error` response added to all operations
- ✅ Missing descriptions added to schema properties and API tags
- ✅ `POST /v1/auth/register` 201 response fixed (changed to 204)
- ✅ Spectral ruleset strengthened with `tag-description`, `operation-500-response`, and `schema-property-description`

## How to verify

```bash
pnpm install
pnpm run lint      # must print: No results with a severity of 'error' found!
pnpm run validate  # must print: No validation issues detected.
```

Closes #47

🤖 Generated with [Claude Code](https://claude.ai/claude-code)