### PR TITLE
fix(spec): add missing format, constraints, and length bounds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,10 @@ Do **not** manually bump versions, tag, or run `generate:swift` before merging �
 - All schema properties have a `description` field (enforced by Spectral)
 - All API tags have a `description` field (enforced by Spectral)
 - Error responses use `application/problem+json` with the `Problem` schema (RFC 9457)
-- Amounts are `integer` in minor currency units (e.g. `1299` = €12.99)
+- Amounts are `integer` with `format: int64` in minor currency units (e.g. `1299` = €12.99); applies to all amount fields across read, write, and update schemas
+- Currency codes are `string` with `minLength: 3` and `maxLength: 3` (ISO 4217)
+- Free-text note fields (`description`) are bounded with `maxLength: 255` across all schemas; nullable update variants (`type: [string, "null"]`) carry the same bound
+- `LoginRequest` mirrors `RegisterRequest` validation: `username` requires `minLength: 3` / `maxLength: 50`, `password` requires `minLength: 8`
 - Write schemas (POST/PUT body) and Update schemas (PATCH body) are separate from read schemas
 - PATCH schemas represent partial updates: fields are optional, and empty patch objects are invalid
 - Auth endpoints override global security with `security: []`

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -538,11 +538,14 @@ components:
       properties:
         username:
           type: string
-          description: The user's registered username.
+          description: The user's registered username (3–50 characters).
+          minLength: 3
+          maxLength: 50
           example: john
         password:
           type: string
-          description: The user's account password.
+          description: The user's account password (minimum 8 characters).
+          minLength: 8
           example: strongpassword123
 
     RefreshTokenRequest:
@@ -657,7 +660,8 @@ components:
           example: 2026-03-08
         description:
           type: string
-          description: Optional free-text note for the transaction.
+          description: Optional free-text note for the transaction (up to 255 characters).
+          maxLength: 255
           example: Coffee
         createdAt:
           type: string
@@ -698,7 +702,8 @@ components:
           description: Date on which the transaction occurred (YYYY-MM-DD).
         description:
           type: string
-          description: Optional free-text note for the transaction.
+          description: Optional free-text note for the transaction (up to 255 characters).
+          maxLength: 255
 
     TransactionUpdate:
       type: object
@@ -711,6 +716,7 @@ components:
           description: UUID of the category to reassign this transaction to.
         amount:
           type: integer
+          format: int64
           description: New amount in minor units. Must be at least 1.
           minimum: 1
         type:
@@ -728,7 +734,8 @@ components:
           description: New transaction date (YYYY-MM-DD).
         description:
           type: [ string, "null" ]
-          description: Updated free-text note. Pass null to clear the existing note.
+          description: Updated free-text note (up to 255 characters). Pass null to clear the existing note.
+          maxLength: 255
 
     PaginationMeta:
       type: object


### PR DESCRIPTION
## Why

Three correctness gaps in `specs/openapi.yaml` caused generated client/server code to miss validation that should be present. Closes #46.

## What changed

- **`specs/openapi.yaml`** — `TransactionUpdate.amount`: added `format: int64` to match `Transaction.amount` and `TransactionWrite.amount`
- **`specs/openapi.yaml`** — `LoginRequest.username`: added `minLength: 3`, `maxLength: 50` to match `RegisterRequest`
- **`specs/openapi.yaml`** — `LoginRequest.password`: added `minLength: 8` to match `RegisterRequest`
- **`specs/openapi.yaml`** — `Transaction.description`, `TransactionWrite.description`, `TransactionUpdate.description`: added `maxLength: 255` (including the nullable `[string, "null"]` update variant)
- **`CLAUDE.md`** — updated Spec conventions to document all four patterns explicitly

## Acceptance criteria

- ✅ `TransactionUpdate.amount` missing `format: int64` — added, now consistent with all other amount fields
- ✅ `LoginRequest` missing validation constraints — `username` and `password` now mirror `RegisterRequest`
- ✅ `Transaction.description` and `currency` missing constraints — `description` bounded with `maxLength: 255` across all three transaction schemas; `currency` already had `minLength: 3` / `maxLength: 3` in all schemas

## How to verify

```bash
pnpm run lint      # No errors (Spectral)
pnpm run validate  # No validation issues (openapi-generator)
```

Then inspect the diff: each changed schema should show the new keyword directly under the field type.