### PR TITLE
fix(release): switch to conventionalcommits preset to support feat! breaking changes

### DIFF
--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -1,8 +1,8 @@
 module.exports = {
   branches: ["main"],
   plugins: [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
+    ["@semantic-release/commit-analyzer", { preset: "conventionalcommits" }],
+    ["@semantic-release/release-notes-generator", { preset: "conventionalcommits" }],
     // Writes CHANGELOG.md (prepare phase, before git commit)
     "@semantic-release/changelog",
     // Bumps package.json version (prepare phase)


### PR DESCRIPTION
## Why

Semantic-release did not release after merging #63 (`feat!: switch pagination from offset/limit to page/size`).

**Root cause:** `conventional-changelog-angular@8.x` — the default preset — has a `headerPattern` that does not include `!`:

```js
/^(\w*)(?:\((.*)\))?: (.*)$/
```

There is also no `breakingHeaderPattern`. Breaking changes are only detected via a `BREAKING CHANGE:` footer keyword. So `feat!:` was parsed, the `!` was silently discarded, `notes` stayed empty, and `whatBump` concluded: no breaking change, no release.

The `conventionalcommits` preset (already installed as `conventional-changelog-conventionalcommits`) has:

```js
headerPattern:         /^(\w*)(?:\((.*)\))?!?: (.*)$/
breakingHeaderPattern: /^(\w*)(?:\((.*)\))?!: (.*)$/
```

`feat!:` will now populate `notes` correctly and trigger a major bump.

## What changed

- `.releaserc.cjs`: `@semantic-release/commit-analyzer` and `@semantic-release/release-notes-generator` both switched from the implicit `angular` preset to `conventionalcommits`

## Effect after merge

When this lands on `main`, the release workflow re-runs and re-analyzes all commits since `v1.4.2`. It will find the `feat!:` commit from #63, correctly classify it as a breaking change, and release `2.0.0`.

## How to verify

After merge, check the release workflow run — semantic-release should log:
```
There are 1 BREAKING CHANGES and 0 features
```
and proceed to publish `2.0.0`.