### PR TITLE
feat: expose client.gen sub-path export in TypeScript package

### DIFF
--- a/config/typescript-package.json
+++ b/config/typescript-package.json
@@ -4,7 +4,8 @@
   "description": "TypeScript API client for Budget Buddy",
   "type": "module",
   "exports": {
-    ".": "./index.ts"
+    ".": "./index.ts",
+    "./client.gen": "./client.gen.ts"
   },
   "types": "./index.ts",
   "repository": {


### PR DESCRIPTION
## Why

The generated `@hey-api/openapi-ts` output includes a `client.gen.ts` file alongside `index.ts`, but the published `package.json` only declared the root `"."` export. Consumers who need to access the raw generated client (e.g. to configure the base URL or inject headers) hit resolution errors in strict ESM bundlers and Node because the sub-path wasn't declared in `exports`.

## What changed

- Added `"./client.gen": "./client.gen.ts"` to the `exports` map in `config/typescript-package.json` — this is the template that CI uses when publishing the npm package, so the new entry will be included in the next release.

## How to verify

1. After merge and release, inspect the published package on GitHub Packages — the `package.json` should contain both `"."` and `"./client.gen"` under `exports`.
2. In a consumer project, confirm `import { ... } from '@budget-buddy-org/budget-buddy-contracts/client.gen'` resolves without bundler or Node ESM errors.
3. Confirm existing `import { ... } from '@budget-buddy-org/budget-buddy-contracts'` still works (root export is unchanged).