### PR TITLE
chore(ci): align workflows and tooling with cross-repo conventions

### DIFF
--- a/.commitlintrc.cjs
+++ b/.commitlintrc.cjs
@@ -1,3 +1,10 @@
 module.exports = {
-  extends: ["@commitlint/config-conventional"],
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'type-enum': [2, 'always', [
+      'feat', 'fix', 'docs', 'style', 'refactor',
+      'perf', 'test', 'build', 'ci', 'chore', 'revert', 'ops',
+    ]],
+    'subject-case': [0],
+  },
 };

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,15 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"
 
-  # Maintain dependencies for npm (Dependabot handles pnpm via the npm ecosystem)
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           version: 10
 
@@ -26,7 +26,9 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Lint commit messages
+        if: github.actor != 'dependabot[bot]'
         run: pnpm exec commitlint --from "${{ github.event.pull_request.base.sha }}" --to "${{ github.event.pull_request.head.sha }}" --verbose
 
       - name: Lint PR title
+        if: github.actor != 'dependabot[bot]'
         run: echo "${{ github.event.pull_request.title }}" | pnpm exec commitlint --verbose

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           version: 10
 
@@ -66,7 +66,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           version: 10
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
           app-id: ${{ secrets.RELEASE_BOT_ID }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           version: 10
 


### PR DESCRIPTION
## Summary

- **commitlint.yml**: skip lint steps for `dependabot[bot]`; unify `pnpm/action-setup` SHA to `fc06bc12` (was `a8198c4b` in this repo, already `fc06bc12` everywhere else)
- **validate.yml / publish.yml**: same pnpm SHA unification (2 more occurrences)
- **release.yml**: update `actions/create-github-app-token` from v1 → v3.1.1
- **.commitlintrc.cjs**: add `ops` type; disable `subject-case` rule (aligns with api and web-app)
- **dependabot.yml**: add `commit-message: prefix: "chore"` so Dependabot PRs don't trigger semantic-release

## Test plan

- [ ] Open a test PR — commitlint workflow should pass for valid conventional commits
- [ ] Verify dependabot PRs are skipped by commitlint (no false failures on bump commits)
- [ ] Confirm release workflow still runs on push to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)