### PR TITLE
feat(spec): add TransactionType schema and type filter for list transactions

### DIFF
--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -290,6 +290,11 @@ paths:
           schema:
             type: string
             format: date
+        - name: type
+          in: query
+          description: Filter by transaction type
+          schema:
+            $ref: "#/components/schemas/TransactionType"
         - name: sort
           in: query
           description: Sort order (by date)
@@ -624,6 +629,13 @@ components:
           maxLength: 255
           example: Dining
 
+    TransactionType:
+      type: string
+      description: Whether a transaction is an outgoing expense or incoming income.
+      enum:
+        - EXPENSE
+        - INCOME
+
     Transaction:
       type: object
       required: [ id, categoryId, amount, type, currency, date ]
@@ -642,11 +654,9 @@ components:
           description: Amount in minor units (e.g. 1299 = €12.99).
           example: 1299
         type:
-          type: string
           description: Whether this transaction is an outgoing expense or incoming income.
-          enum:
-            - EXPENSE
-            - INCOME
+          allOf:
+            - $ref: "#/components/schemas/TransactionType"
         currency:
           type: string
           description: ISO 4217 three-letter currency code.
@@ -687,9 +697,9 @@ components:
           minimum: 1
           example: 1299
         type:
-          type: string
           description: Whether this transaction is an outgoing expense or incoming income.
-          enum: [ EXPENSE, INCOME ]
+          allOf:
+            - $ref: "#/components/schemas/TransactionType"
         currency:
           type: string
           description: ISO 4217 three-letter currency code.
@@ -720,9 +730,9 @@ components:
           description: New amount in minor units. Must be at least 1.
           minimum: 1
         type:
-          type: string
-          description: New transaction type (EXPENSE or INCOME).
-          enum: [ EXPENSE, INCOME ]
+          description: New transaction type.
+          allOf:
+            - $ref: "#/components/schemas/TransactionType"
         currency:
           type: string
           description: New ISO 4217 three-letter currency code.


### PR DESCRIPTION
## Why

The `EXPENSE`/`INCOME` enum was copy-pasted inline across three schemas (`Transaction`, `TransactionWrite`, `TransactionUpdate`), creating a drift risk. There was also no way to filter the transaction list by type.

## What changed

- **New `TransactionType` schema** in `components/schemas` — single canonical definition of the `EXPENSE | INCOME` enum with a shared description
- **`Transaction.type`, `TransactionWrite.type`, `TransactionUpdate.type`** — replaced inline enum definitions with `allOf: [$ref: TransactionType]` references, following the spec's `$ref`+description convention
- **New `type` query parameter on `GET /v1/transactions`** — bare `$ref` to `TransactionType` (description lives on the parameter, not the schema, so no `allOf` wrapper needed)

## How to verify

- `pnpm run lint` — no errors
- `pnpm run validate` — passes structural validation
- Check generated TypeScript: a single `TransactionType` enum type should be emitted and reused across all three schemas and the list operation parameters
- Check generated Java: same — one `TransactionTypeEnum` used everywhere instead of three separate anonymous enums