### PR TITLE
feat!: remove auth endpoints from OpenAPI spec

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,9 +93,8 @@ Do **not** manually bump versions, tag, or run `generate:swift` before merging �
 - Amounts are `integer` with `format: int64` in minor currency units (e.g. `1299` = €12.99); applies to all amount fields across read, write, and update schemas
 - Currency codes are `string` with `minLength: 3` and `maxLength: 3` (ISO 4217)
 - Free-text note fields (`description`) are bounded with `maxLength: 255` across all schemas; nullable update variants (`type: [string, "null"]`) carry the same bound
-- `LoginRequest` mirrors `RegisterRequest` validation: `username` requires `minLength: 3` / `maxLength: 50`, `password` requires `minLength: 8`
 - Write schemas (POST/PUT body) and Update schemas (PATCH body) are separate from read schemas
 - PATCH schemas represent partial updates: fields are optional, and empty patch objects are invalid
 - List endpoints (`GET /v1/categories`, `GET /v1/transactions`) use `page` (zero-based, min 0, default 0) and `size` (min 1, max 200, default 20) query parameters; `PaginationMeta` returns `page`, `size`, and `total`
-- Auth endpoints override global security with `security: []`
+- Authentication is handled externally by Zitadel (OIDC); no auth endpoints exist in this spec — all endpoints require `BearerAuth` (Zitadel-issued JWTs)
 - When adding a `description` alongside a `$ref`, use `allOf` wrapping: `allOf: [{$ref: ...}]` with `description` as a sibling — avoids Spectral false positives with bare `$ref` + `description`

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -21,8 +21,6 @@ servers:
         default: localhost:8080
 
 tags:
-  - name: auth
-    description: Authentication — register, login, refresh, and logout.
   - name: categories
     description: Manage spending categories for the authenticated user.
   - name: transactions
@@ -32,93 +30,6 @@ security:
   - BearerAuth: [ ]
 
 paths:
-  /v1/auth/login:
-    post:
-      tags: [ auth ]
-      summary: Authenticate user
-      description: Authenticates a user with username and password, returning access and refresh tokens.
-      operationId: loginUser
-      security: [ ]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/LoginRequest"
-      responses:
-        "200":
-          description: Authentication tokens
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthToken"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-
-  /v1/auth/refresh:
-    post:
-      tags: [ auth ]
-      summary: Refresh access token
-      description: Exchanges a valid refresh token for a new access token.
-      operationId: refreshToken
-      security: [ ]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/RefreshTokenRequest"
-      responses:
-        "200":
-          description: New tokens
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthToken"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-
-  /v1/auth/register:
-    post:
-      tags: [ auth ]
-      summary: Register new user
-      description: Creates a new user account with the provided credentials.
-      operationId: registerUser
-      security: [ ]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/RegisterRequest"
-      responses:
-        "204":
-          description: User created successfully
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "409":
-          $ref: "#/components/responses/Conflict"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-
-  /v1/auth/logout:
-    post:
-      tags: [ auth ]
-      summary: Logout user and invalidate refresh tokens
-      description: Invalidates the current user's refresh tokens, ending their session.
-      operationId: logoutUser
-      responses:
-        "204":
-          description: Logged out successfully
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-
   /v1/categories:
     get:
       tags: [ categories ]
@@ -506,13 +417,6 @@ components:
           schema:
             $ref: "#/components/schemas/Problem"
 
-    Conflict:
-      description: Resource already exists
-      content:
-        application/problem+json:
-          schema:
-            $ref: "#/components/schemas/Problem"
-
     InternalServerError:
       description: Unexpected server error
       content:
@@ -521,69 +425,6 @@ components:
             $ref: "#/components/schemas/Problem"
 
   schemas:
-    RegisterRequest:
-      type: object
-      required: [ username, password ]
-      properties:
-        username:
-          type: string
-          description: Unique username chosen by the user (3–50 characters).
-          minLength: 3
-          maxLength: 50
-          example: john
-        password:
-          type: string
-          description: Account password (minimum 8 characters).
-          minLength: 8
-          example: strongpassword123
-
-    LoginRequest:
-      type: object
-      required: [ username, password ]
-      properties:
-        username:
-          type: string
-          description: The user's registered username (3–50 characters).
-          minLength: 3
-          maxLength: 50
-          example: john
-        password:
-          type: string
-          description: The user's account password (minimum 8 characters).
-          minLength: 8
-          example: strongpassword123
-
-    RefreshTokenRequest:
-      type: object
-      required: [ refresh_token ]
-      properties:
-        refresh_token:
-          type: string
-          description: Opaque refresh token
-          example: d74855a0aba429506a0b0423e79ff475
-
-    AuthToken:
-      type: object
-      required: [ access_token, token_type, expires_in, refresh_token ]
-      properties:
-        access_token:
-          type: string
-          description: JWT access token used in the Authorization header for subsequent requests.
-        token_type:
-          type: string
-          description: Token type, always "Bearer".
-          example: Bearer
-        expires_in:
-          type: integer
-          description: Lifetime of the access token in seconds.
-          example: 3600
-        refresh_token:
-          type: string
-          description: Opaque refresh token
-        scope:
-          type: string
-          description: Space-separated list of granted scopes, if applicable
-
     Category:
       type: object
       required: [ id, name ]


### PR DESCRIPTION
## Why

Zitadel now handles authentication natively (OIDC). The four auth endpoints in the Budget Buddy API contract are no longer needed — closes #73.

## What changed

- **Removed paths:** `POST /v1/auth/login`, `/v1/auth/register`, `/v1/auth/refresh`, `/v1/auth/logout`
- **Removed schemas:** `LoginRequest`, `RegisterRequest`, `RefreshTokenRequest`, `AuthToken`
- **Removed:** `auth` tag and `Conflict` reusable response (only used by register)
- **Retained:** `BearerAuth` security scheme (tokens are now Zitadel-issued JWTs)
- **Updated:** `CLAUDE.md` spec conventions to reflect Zitadel-based auth

## Acceptance criteria

- ✅ All four `/v1/auth/**` paths removed from `specs/openapi.yaml`
- ✅ All four auth schemas removed from `specs/openapi.yaml`
- ✅ `BearerAuth` security scheme retained
- ✅ `pnpm run lint` passes (no errors)
- ✅ `pnpm run validate` passes (no issues)
- ✅ Version bump — handled by semantic-release via `feat!:` prefix → 3.0.0

## How to verify

1. `pnpm run lint` — no errors
2. `pnpm run validate` — no validation issues
3. `pnpm run generate` — all three clients generate successfully
4. Confirm `BearerAuth` is still present in `components/securitySchemes`
5. Confirm no `/v1/auth` paths remain in the spec

## Notes

- This is phase 1 of the Zitadel migration. Downstream repos (API #116/#117/#119, web-app #61/#62/#63) depend on this spec change.
- The `Conflict` response component was removed since it was only referenced by the register endpoint. It can be re-added if needed by a future endpoint.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)