### PR TITLE
docs(security): document DPoP authorization scheme in BearerAuth

### DIFF
--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -356,6 +356,22 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
+      description: |
+        OIDC-issued JWT access token. The API accepts two equivalent authorization
+        schemes at the HTTP layer:
+
+        - `Authorization: Bearer <jwt>` — standard bearer token. Used by
+          non-browser clients (iOS, Telegram bot, server-to-server callers) where
+          the access token is already stored in a hardware-backed keystore.
+        - `Authorization: DPoP <jwt>` + `DPoP: <proof>` — sender-constrained
+          token per [RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449).
+          Used by the browser web app, which holds a non-extractable keypair in
+          IndexedDB. Even if the token is exfiltrated, it cannot be replayed
+          from another origin or device.
+
+        This scheme document describes the bearer variant; DPoP is a protocol-level
+        concern handled by the resource server (Spring Security 7 auto-wires it)
+        and does not change any endpoint shape.
 
   parameters:
     categoryId:


### PR DESCRIPTION
## Summary

Expand the description on the `BearerAuth` security scheme to document that the API accepts two authorization schemes:

- `Authorization: Bearer <jwt>` — standard bearer token, used by non-browser clients (iOS, Telegram bot, server-to-server) where the access token already sits in a hardware-backed keystore.
- `Authorization: DPoP <jwt>` + `DPoP: <proof>` — sender-constrained token per [RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449), used by the browser SPA. The SPA holds a non-extractable keypair in IndexedDB; even if an access or refresh token is exfiltrated, it cannot be replayed from another origin or device.

Pure docs — no endpoint shape, schema, or generator output changes. OpenAPI 3.1 has no native DPoP security scheme, so the semantics live in the `BearerAuth.description` field.

## Test plan

- [x] `pnpm run lint` (Spectral)
- [x] `pnpm run validate` (openapi-generator)
- [ ] TS/Java/Swift clients still compile with no diff against the current output (verify in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)