### PR TITLE
docs(security): revert BearerAuth description to single-line baseline

### DIFF
--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -357,21 +357,7 @@ components:
       scheme: bearer
       bearerFormat: JWT
       description: |
-        OIDC-issued JWT access token. The API accepts two equivalent authorization
-        schemes at the HTTP layer:
-
-        - `Authorization: Bearer <jwt>` — standard bearer token. Used by
-          non-browser clients (iOS, Telegram bot, server-to-server callers) where
-          the access token is already stored in a hardware-backed keystore.
-        - `Authorization: DPoP <jwt>` + `DPoP: <proof>` — sender-constrained
-          token per [RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449).
-          Used by the browser web app, which holds a non-extractable keypair in
-          IndexedDB. Even if the token is exfiltrated, it cannot be replayed
-          from another origin or device.
-
-        This scheme document describes the bearer variant; DPoP is a protocol-level
-        concern handled by the resource server (Spring Security 7 auto-wires it)
-        and does not change any endpoint shape.
+        OIDC-issued JWT access token, sent as `Authorization: Bearer <jwt>`.
 
   parameters:
     categoryId:


### PR DESCRIPTION
## Summary

The `BearerAuth.description` shipped in #81 expanded into a paragraph about DPoP-bound tokens. The web app's DPoP plumbing has now been removed (the IdP doesn't support it — see `budget-buddy-web-app#114`), so the description no longer matches reality. Strip it back to a single-line statement that just says what `BearerAuth` is.

Pure docs. No schema or generator output change.

## Test plan

- [x] `pnpm run lint` (Spectral)
- [x] `pnpm run validate` (openapi-generator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)