### PR TITLE
feat: add per-category monthly budget and spending summary endpoint

### DIFF
--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -109,10 +109,7 @@ paths:
           required: true
           description: ISO 4217 three-letter currency code. Only transactions in this currency contribute to `spent`.
           schema:
-            type: string
-            minLength: 3
-            maxLength: 3
-            example: EUR
+            $ref: "#/components/schemas/Currency"
       responses:
         "200":
           description: Per-category spending summary for the requested month and currency
@@ -555,6 +552,13 @@ components:
           description: New monthly budget in minor units. Pass null to clear an existing budget.
           example: 75000
 
+    Currency:
+      type: string
+      description: ISO 4217 three-letter currency code (uppercase).
+      minLength: 3
+      maxLength: 3
+      example: EUR
+
     TransactionType:
       type: string
       description: Whether a transaction is an outgoing expense or incoming income.
@@ -584,11 +588,9 @@ components:
           allOf:
             - $ref: "#/components/schemas/TransactionType"
         currency:
-          type: string
           description: ISO 4217 three-letter currency code.
-          minLength: 3
-          maxLength: 3
-          example: EUR
+          allOf:
+            - $ref: "#/components/schemas/Currency"
         date:
           type: string
           format: date
@@ -627,11 +629,9 @@ components:
           allOf:
             - $ref: "#/components/schemas/TransactionType"
         currency:
-          type: string
           description: ISO 4217 three-letter currency code.
-          minLength: 3
-          maxLength: 3
-          example: EUR
+          allOf:
+            - $ref: "#/components/schemas/Currency"
         date:
           type: string
           format: date
@@ -660,10 +660,9 @@ components:
           allOf:
             - $ref: "#/components/schemas/TransactionType"
         currency:
-          type: string
           description: New ISO 4217 three-letter currency code.
-          minLength: 3
-          maxLength: 3
+          allOf:
+            - $ref: "#/components/schemas/Currency"
         date:
           type: string
           format: date
@@ -746,11 +745,9 @@ components:
           description: Calendar month echoed back from the request, formatted YYYY-MM.
           example: "2026-05"
         currency:
-          type: string
-          minLength: 3
-          maxLength: 3
           description: ISO 4217 currency code echoed back from the request.
-          example: EUR
+          allOf:
+            - $ref: "#/components/schemas/Currency"
         items:
           type: array
           description: One row per category owned by the authenticated user, including categories with zero spending.

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -82,6 +82,51 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /v1/categories/summary:
+    get:
+      tags: [ categories ]
+      summary: Per-category spending summary
+      description: |
+        Returns per-category spending and budget rollup for a single calendar month, in a single
+        currency. Includes every category owned by the authenticated user (even with zero spending)
+        so dashboards can render budgets at 0% used without a second request.
+
+        Only `EXPENSE` transactions whose `currency` matches the requested currency contribute to
+        `spent` and `transactionCount`. Transactions in other currencies are reflected in
+        `excludedTransactionCount` so the UI can surface an informational note.
+      operationId: getCategoriesSummary
+      parameters:
+        - name: month
+          in: query
+          required: true
+          description: Calendar month to summarise, formatted YYYY-MM. Interpreted in UTC.
+          schema:
+            type: string
+            pattern: "^\\d{4}-(0[1-9]|1[0-2])$"
+            example: "2026-05"
+        - name: currency
+          in: query
+          required: true
+          description: ISO 4217 three-letter currency code. Only transactions in this currency contribute to `spent`.
+          schema:
+            type: string
+            minLength: 3
+            maxLength: 3
+            example: EUR
+      responses:
+        "200":
+          description: Per-category spending summary for the requested month and currency
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CategorySpendingSummary"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
   /v1/categories/{categoryId}:
     parameters:
       - $ref: "#/components/parameters/categoryId"
@@ -460,6 +505,12 @@ components:
           type: string
           description: Human-readable name of the category.
           example: Groceries
+        monthlyBudget:
+          type: [ integer, "null" ]
+          format: int64
+          minimum: 0
+          description: Monthly spending budget for this category, in minor units (e.g. 50000 = €500.00). Null means no budget set.
+          example: 50000
         createdAt:
           type: string
           format: date-time
@@ -479,6 +530,12 @@ components:
           minLength: 1
           maxLength: 255
           example: Restaurants
+        monthlyBudget:
+          type: [ integer, "null" ]
+          format: int64
+          minimum: 0
+          description: Monthly spending budget for this category, in minor units. Omit or pass null for no budget.
+          example: 50000
 
     CategoryUpdate:
       type: object
@@ -491,6 +548,12 @@ components:
           minLength: 1
           maxLength: 255
           example: Dining
+        monthlyBudget:
+          type: [ integer, "null" ]
+          format: int64
+          minimum: 0
+          description: New monthly budget in minor units. Pass null to clear an existing budget.
+          example: 75000
 
     TransactionType:
       type: string
@@ -638,6 +701,61 @@ components:
           description: Pagination metadata for the current response.
           allOf:
             - $ref: "#/components/schemas/PaginationMeta"
+
+    CategorySpendingRow:
+      type: object
+      required: [ categoryId, categoryName, spent, transactionCount, excludedTransactionCount ]
+      properties:
+        categoryId:
+          type: string
+          format: uuid
+          description: UUID of the category this row summarises.
+        categoryName:
+          type: string
+          description: Human-readable name of the category at the time of the response.
+        monthlyBudget:
+          type: [ integer, "null" ]
+          format: int64
+          minimum: 0
+          description: Snapshot of the category's current monthly budget, in minor units. Null when no budget is set.
+          example: 50000
+        spent:
+          type: integer
+          format: int64
+          minimum: 0
+          description: Sum of EXPENSE transactions in the requested currency for this month, in minor units.
+          example: 32450
+        transactionCount:
+          type: integer
+          minimum: 0
+          description: Number of EXPENSE transactions contributing to `spent`.
+          example: 12
+        excludedTransactionCount:
+          type: integer
+          minimum: 0
+          description: Number of EXPENSE transactions in this month for this category whose currency did not match the requested currency and were therefore not summed.
+          example: 0
+
+    CategorySpendingSummary:
+      type: object
+      required: [ month, currency, items ]
+      properties:
+        month:
+          type: string
+          pattern: "^\\d{4}-(0[1-9]|1[0-2])$"
+          description: Calendar month echoed back from the request, formatted YYYY-MM.
+          example: "2026-05"
+        currency:
+          type: string
+          minLength: 3
+          maxLength: 3
+          description: ISO 4217 currency code echoed back from the request.
+          example: EUR
+        items:
+          type: array
+          description: One row per category owned by the authenticated user, including categories with zero spending.
+          items:
+            $ref: "#/components/schemas/CategorySpendingRow"
 
     PaginatedTransactions:
       type: object


### PR DESCRIPTION
Closes #92.

## Summary

- Adds optional, nullable `monthlyBudget` (minor units, `int64`, `minimum: 0`) to `Category`, `CategoryWrite`, and `CategoryUpdate`. `null` / absent = no budget set; `0` = explicit zero (different states).
- Adds `GET /v1/categories/summary?month=YYYY-MM&currency=XXX` returning a single-currency, single-month rollup per category — `monthlyBudget`, `spent`, `transactionCount`, plus `excludedTransactionCount` for transactions in non-matching currencies.
- Includes **all** categories owned by the user in the response (even zero-spend) so dashboards render budgets at 0% used without a second roundtrip.
- Sums `EXPENSE` only.
- No pagination — category counts are naturally small.
- No `currency` on `Category`. The implicit contract is "budget is in the user's preferred currency", matching how YNAB/Monarch work. The web app passes its preferred currency on the summary call; this becomes a server-side default later if/when user prefs land server-side.

## Why scalar `spent` (not per-currency array)

YAGNI for multi-currency. Real multi-currency support needs FX rates, historical rates, and a base currency — a per-currency array defers but doesn't solve those. Bumping `spent` to a richer shape later is a mechanical v2 of the response. Scalar today is permanent simplicity for clients.

## Versioning

Strictly additive → MINOR bump. semantic-release will tag `v3.3.0` from this `feat:` commit.

## Test plan

- [x] `pnpm run lint` — no errors
- [x] `pnpm run validate` — no issues
- [x] `pnpm run generate:ts` — succeeds
- [x] `pnpm run generate:java` — succeeds; `CategoriesApi.getCategoriesSummary` and `CategorySpendingSummary` / `CategorySpendingRow` models present
- [x] CI green on validate workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)