### PR TITLE
feat: add getTransactionsSummaryTrend endpoint

### DIFF
--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -219,22 +219,64 @@ paths:
   /v1/transactions/summary:
     get:
       tags: [ transactions ]
-      summary: Monthly income, expense, and balance summary over a month range
+      summary: Monthly income, expense, and balance summary
       description: |
-        Returns monthly income, expense, and balance totals for an inclusive range of calendar
-        months, in a single currency, scoped to the authenticated user. Each element in the
-        response is one calendar month bucket. Months in the range with no matching transactions
-        are returned with zeroed totals, so the response array length always equals the number
-        of months between `from` and `to` inclusive.
+        Returns monthly income, expense, and balance totals for a single calendar month, in a
+        single currency, scoped to the authenticated user.
 
         Only transactions whose `currency` matches the requested currency contribute to `income`,
         `expense`, `balance`, `incomeCount`, and `expenseCount`. Transactions in other currencies
         are reflected in `excludedTransactionCount` so the UI can surface an informational note.
-
-        For a single month, set `from` and `to` to the same value; the response is a 1-element
-        array. The maximum allowed range is 24 months — wider ranges are rejected with 400 to
-        bound query cost.
       operationId: getTransactionsSummary
+      parameters:
+        - name: month
+          in: query
+          required: true
+          description: Calendar month to summarise, formatted YYYY-MM. Interpreted in UTC.
+          schema:
+            type: string
+            pattern: "^\\d{4}-(0[1-9]|1[0-2])$"
+            example: "2026-05"
+        - name: currency
+          in: query
+          required: true
+          description: ISO 4217 three-letter currency code. Only transactions in this currency contribute to income/expense.
+          schema:
+            $ref: "#/components/schemas/Currency"
+      responses:
+        "200":
+          description: Monthly summary for the requested month and currency
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MonthlySummary"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /v1/transactions/summary/trend:
+    get:
+      tags: [ transactions ]
+      summary: Monthly summary trend across a month range
+      description: |
+        Returns one `MonthlySummary` per calendar month across an inclusive range, in a single
+        currency, scoped to the authenticated user. Intended for sparkline / trend visualisations
+        that need per-month buckets in a single request.
+
+        Months in the range with no matching transactions are returned with zeroed totals, so
+        the response array length always equals the number of months between `from` and `to`
+        inclusive. Buckets are ordered oldest first.
+
+        Only transactions whose `currency` matches the requested currency contribute to `income`,
+        `expense`, `balance`, `incomeCount`, and `expenseCount`. Transactions in other currencies
+        are reflected in `excludedTransactionCount`.
+
+        The maximum allowed range is 24 months — wider ranges are rejected with 400 to bound
+        query cost.
+      operationId: getTransactionsSummaryTrend
       parameters:
         - name: from
           in: query
@@ -260,7 +302,7 @@ paths:
             $ref: "#/components/schemas/Currency"
       responses:
         "200":
-          description: One monthly summary per calendar month in the requested range, oldest first.
+          description: One `MonthlySummary` per calendar month in the requested range, oldest first.
           content:
             application/json:
               schema:
@@ -820,7 +862,7 @@ components:
         month:
           type: string
           pattern: "^\\d{4}-(0[1-9]|1[0-2])$"
-          description: Calendar month this bucket represents, formatted YYYY-MM.
+          description: Calendar month this summary covers, formatted YYYY-MM.
           example: "2026-05"
         currency:
           description: ISO 4217 currency code echoed back from the request.

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -219,20 +219,35 @@ paths:
   /v1/transactions/summary:
     get:
       tags: [ transactions ]
-      summary: Monthly income, expense, and balance summary
+      summary: Monthly income, expense, and balance summary over a month range
       description: |
-        Returns monthly income, expense, and balance totals for a single calendar month, in a
-        single currency, scoped to the authenticated user.
+        Returns monthly income, expense, and balance totals for an inclusive range of calendar
+        months, in a single currency, scoped to the authenticated user. Each element in the
+        response is one calendar month bucket. Months in the range with no matching transactions
+        are returned with zeroed totals, so the response array length always equals the number
+        of months between `from` and `to` inclusive.
 
         Only transactions whose `currency` matches the requested currency contribute to `income`,
         `expense`, `balance`, `incomeCount`, and `expenseCount`. Transactions in other currencies
         are reflected in `excludedTransactionCount` so the UI can surface an informational note.
+
+        For a single month, set `from` and `to` to the same value; the response is a 1-element
+        array. The maximum allowed range is 24 months — wider ranges are rejected with 400 to
+        bound query cost.
       operationId: getTransactionsSummary
       parameters:
-        - name: month
+        - name: from
           in: query
           required: true
-          description: Calendar month to summarise, formatted YYYY-MM. Interpreted in UTC.
+          description: First calendar month in the range (inclusive), formatted YYYY-MM. Interpreted in UTC.
+          schema:
+            type: string
+            pattern: "^\\d{4}-(0[1-9]|1[0-2])$"
+            example: "2025-12"
+        - name: to
+          in: query
+          required: true
+          description: Last calendar month in the range (inclusive), formatted YYYY-MM. Must be greater than or equal to `from`, and no more than 24 months after `from`.
           schema:
             type: string
             pattern: "^\\d{4}-(0[1-9]|1[0-2])$"
@@ -245,11 +260,13 @@ paths:
             $ref: "#/components/schemas/Currency"
       responses:
         "200":
-          description: Monthly summary for the requested month and currency
+          description: One monthly summary per calendar month in the requested range, oldest first.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MonthlySummary"
+                type: array
+                items:
+                  $ref: "#/components/schemas/MonthlySummary"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -803,7 +820,7 @@ components:
         month:
           type: string
           pattern: "^\\d{4}-(0[1-9]|1[0-2])$"
-          description: Calendar month echoed back from the request, formatted YYYY-MM.
+          description: Calendar month this bucket represents, formatted YYYY-MM.
           example: "2026-05"
         currency:
           description: ISO 4217 currency code echoed back from the request.


### PR DESCRIPTION
## Summary

Adds `GET /v1/transactions/summary/trend` for per-month bucket data. `getTransactionsSummary` is **untouched** — single-month callers keep their existing single-object response.

- New endpoint: `getTransactionsSummaryTrend(from, to, currency)` → `MonthlySummary[]`
- Range is inclusive YYYY-MM; oldest first; empty months zero-filled so array length matches the requested range; max 24 months.

## Why two endpoints instead of overloading the existing one

The dashboard fans out 6 parallel `getTransactionsSummary` calls to populate sparklines. The original plan was to replace `month` with `from`/`to` and always return an array — collapses 6→1 calls but forces every single-month consumer (Balance / Income / Expenses cards) to do `data[0]` to unwrap. The single-object endpoint and the array endpoint are different shapes serving different needs; cleaner to separate them.

Tradeoff acknowledged: small surface bump (one new operation) vs. zero `[0]` unwrapping anywhere in callers, and each operation's name and response honestly describe what it does.

## Notes

- Categories summary endpoint is intentionally untouched: budgets are inherently monthly, so a range param would muddy `monthlyBudget` semantics.
- Pre-1.0 → no deprecation/aliases; this is purely additive.

## Test plan

- [ ] `npm run lint` passes
- [ ] `npm run validate` passes
- [ ] `npm run generate` succeeds for all three targets
- [ ] API impl PR adds the trend endpoint
- [ ] Web app PR consumes the new shape on the sparkline path; existing `useMonthlySummary` is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)