### PR TITLE
refactor!: harden and DRY OpenAPI schema, modernize tooling

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -15,8 +15,6 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
-        with:
-          version: 10
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,8 +25,6 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
-        with:
-          version: 10
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -67,8 +65,6 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
-        with:
-          version: 10
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,6 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
-        with:
-          version: 10
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,8 +19,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
-        with:
-          version: 10
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The core of this project is the OpenAPI specification located in `specs/openapi.
 
 | Target | Technology | Delivery Method | Usage |
 | :--- | :--- | :--- | :--- |
-| **Frontend** | TypeScript + Axios | GitHub Packages (npm) | Web dashboard |
+| **Frontend** | TypeScript (fetch) | GitHub Packages (npm) | Web dashboard |
 | **Backend** | Java + Spring Boot | GitHub Packages (Maven) | API Service implementation |
 | **Mobile** | Swift 6 | Git Repo (SPM) | iOS / macOS application |
 
@@ -32,49 +32,49 @@ The core of this project is the OpenAPI specification located in `specs/openapi.
 
 ### Prerequisites
 - [Node.js](https://nodejs.org/) (v24+)
-- [pnpm](https://pnpm.io/) (v10+)
-- [OpenAPI Generator CLI](https://openapi-generator.tech/docs/installation)
-- [Spectral CLI](https://meta.stoplight.io/docs/spectral/docs/guides/1-getting-started.md)
+- [pnpm](https://pnpm.io/) — pinned via Corepack from the `packageManager` field; run `corepack enable` once
 
 ```bash
-pnpm install
+pnpm install   # installs Spectral and openapi-generator-cli as devDeps
 ```
 
 ### Core Commands
 
 | Command | Description |
 | :--- | :--- |
-| `pnpm run lint` | Lints the spec with Spectral (enforces `operationId` and naming conventions). |
+| `pnpm run lint` | Lints the spec with Spectral (operationId, tags, descriptions, 500 responses). |
 | `pnpm run validate` | Checks the structural integrity of the OpenAPI document. |
 | `pnpm run mock` | Runs a Prism mock server locally at `http://localhost:4010`. |
 | `pnpm run generate` | Generates all clients (TS, Java, Swift) locally. |
-| `pnpm run generate:swift` | Specifically updates the committed Swift source files. |
+| `pnpm run generate:swift` | Regenerates the committed Swift sources under `Sources/BudgetBuddyContracts/`. |
 
 ---
 
 ## 📦 Usage
 
+See the [GitHub Release badge](#) above for the latest version.
+
 ### Swift (iOS/macOS)
 Add this repository as a dependency in your `Package.swift`:
 ```swift
 dependencies: [
-    .package(url: "https://github.com/budget-buddy-org/budget-buddy-contracts.git", from: "1.1.0")
+    .package(url: "https://github.com/budget-buddy-org/budget-buddy-contracts.git", from: "<latest>")
 ]
 ```
 
 ### TypeScript (Web)
-Install from GitHub Packages (requires `.npmrc` configuration):
+Install from GitHub Packages (requires `.npmrc` configuration pointing `@budget-buddy-org` to `https://npm.pkg.github.com`):
 ```bash
 pnpm add @budget-buddy-org/budget-buddy-contracts
 ```
 
 ### Java (Spring Boot)
-Add to your `pom.xml`:
+Add to your `pom.xml` (requires Maven server credentials for GitHub Packages):
 ```xml
 <dependency>
     <groupId>com.budgetbuddy</groupId>
     <artifactId>budget-buddy-contracts</artifactId>
-    <version>1.1.0</version>
+    <version><!-- latest --></version>
 </dependency>
 ```
 
@@ -82,30 +82,32 @@ Add to your `pom.xml`:
 
 ## 🚦 Release Workflow
 
-1. **Modify the Spec:** Edit `specs/openapi.yaml`.
-2. **Use Conventional Commits:** Merge changes to `main` with commit messages such as `feat(spec): add category color` or `fix(auth): clarify refresh token schema`.
-3. **Automatic Release:** The `Release` GitHub Action runs on every push to `main`, calculates the next semantic version from commit history, then automatically:
-   - bumps `package.json` and `specs/openapi.yaml` to the new version
-   - regenerates and commits the Swift sources in `Sources/BudgetBuddyContracts/`
+1. **Edit the spec:** `specs/openapi.yaml` (and/or `config/*.yaml`).
+2. **Lint and validate:** `pnpm run lint && pnpm run validate`.
+3. **Open a PR with a conventional-commit title** (`feat:`, `fix:`, `feat!:`, …). PRs are squash-merged, so the PR title becomes the commit on `main` and drives semantic-release.
+4. **CI does the rest** — on push to `main`, the release pipeline:
+   - calculates the next semver from commit history
+   - bumps `package.json` and `specs/openapi.yaml` to that version
+   - regenerates and commits the Swift sources under `Sources/BudgetBuddyContracts/`
    - updates `CHANGELOG.md`
    - creates the Git tag and GitHub Release
-   - publishes the generated TypeScript client to GitHub Packages
-   - publishes the generated Java Spring stubs to GitHub Packages
+   - publishes the TypeScript client to GitHub Packages (npm)
+   - publishes the Java Spring stubs to GitHub Packages (Maven)
 
-### Commit Message Enforcement
+### Commit message enforcement
 
 - Local commits are checked by Husky + Commitlint.
-- Pull requests are checked again in CI, so invalid commit messages cannot be merged accidentally.
+- PRs are re-checked in CI; invalid messages cannot be merged.
 - Release impact follows Conventional Commits:
-  - `fix:` and `perf:` => patch
-  - `feat:` => minor
-  - `!` or `BREAKING CHANGE:` => major
+  - `fix:` / `perf:` → patch
+  - `feat:` → minor
+  - `!` suffix or `BREAKING CHANGE:` footer → major
 
 ---
 
 ## 📝 API Design Conventions
 
-- **Currency:** All monetary amounts are handled as `integers` in minor units (e.g., `$10.50` is represented as `1050`).
-- **Errors:** We follow **RFC 9457** (Problem Details for HTTP APIs). Every error response uses the `application/problem+json` content type.
-- **Pagination:** Collections use a standardized `PaginationMeta` object containing `total`, `limit`, and `offset`.
-- **Auth:** Bearer Token (JWT) is used globally except for login/register endpoints.
+- **Currency:** Monetary amounts are `integer` (`int64`) in minor units — e.g. `1050` = `€10.50`. ISO 4217 codes accompany every amount.
+- **Errors:** Every error response uses `application/problem+json` per **RFC 9457**. Field-level validation errors are surfaced as `Problem.errors[]` on `400` responses.
+- **Pagination:** List endpoints accept `page` (zero-based, default 0) and `size` (1–200, default 20) query parameters; the response carries a `PaginationMeta` with `page`, `size`, and `total`.
+- **Auth:** Every endpoint requires a Bearer JWT issued by the OIDC provider — there are no auth endpoints in this spec.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@commitlint/cli": "^21.0.1",
     "@commitlint/config-conventional": "^21.0.1",
-    "@hey-api/openapi-ts": "^0.97.2",
+    "@hey-api/openapi-ts": "^0.97.3",
     "@openapitools/openapi-generator-cli": "^2.34.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/commit-analyzer": "^13.0.1",
@@ -35,5 +35,6 @@
     "@stoplight/spectral-cli": "^6.16.0",
     "husky": "^9.1.7",
     "semantic-release": "^25.0.3"
-  }
+  },
+  "packageManager": "pnpm@11.4.0+sha512.f0febc7e37552ab485494a914241b338e0b3580b93d54ce31f00933015880863129038a1b4ae4e414a0ee63ac35bf21197e990172c4a68256450b5636310968f"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,13 +10,13 @@ importers:
     devDependencies:
       '@commitlint/cli':
         specifier: ^21.0.1
-        version: 21.0.1(@types/node@25.8.0)(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(typescript@6.0.2)
+        version: 21.0.1(@types/node@25.9.1)(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(typescript@6.0.2)
       '@commitlint/config-conventional':
         specifier: ^21.0.1
         version: 21.0.1
       '@hey-api/openapi-ts':
-        specifier: ^0.97.2
-        version: 0.97.2(typescript@6.0.2)
+        specifier: ^0.97.3
+        version: 0.97.3(typescript@6.0.2)
       '@openapitools/openapi-generator-cli':
         specifier: ^2.34.0
         version: 2.34.0
@@ -68,12 +68,12 @@ packages:
   '@asyncapi/specs@6.11.1':
     resolution: {integrity: sha512-A3WBLqAKGoJ2+6FWFtpjBlCQ1oFCcs4GxF7zsIGvNqp/klGUHjlA3aAcZ9XMMpLGE8zPeYDz2x9FmO6DSuKraQ==}
 
-  '@babel/code-frame@7.29.0':
-    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
   '@borewit/text-codec@0.2.2':
@@ -164,23 +164,23 @@ packages:
       conventional-commits-parser:
         optional: true
 
-  '@hey-api/codegen-core@0.8.1':
-    resolution: {integrity: sha512-Iciv2vUCJTW9lWM/ROvyZLblmcbYJHPuXfzb1SzeDVVn4xEXu2ilLU1pq3fn+09FZ/Y0P7VyvRE47UDU6om8xA==}
+  '@hey-api/codegen-core@0.8.2':
+    resolution: {integrity: sha512-R2NMf3wq97rh1mjz33WJQU8svz3F0RYUjvx/QzXucjpSqQ3O5huTdDjErG4fMxSr1X+X56NuDrqtGfHmo1TRUQ==}
     engines: {node: '>=22.13.0'}
 
   '@hey-api/json-schema-ref-parser@1.4.2':
     resolution: {integrity: sha512-ZhCFSKI2ipZHEbgmtUHdyddvRU3wJ4elgCfYUC7T7hZa4EivSrVflTQf2w+v3TuaYxR1Y2V2kq3otqTttrrK8Q==}
     engines: {node: '>=22.13.0'}
 
-  '@hey-api/openapi-ts@0.97.2':
-    resolution: {integrity: sha512-nA+y0/I5O9loQMeJKumi6BQ40/Y71N0hIMmXZ/I7rh8jEOzYxSxmf5a4TBEI2Ap4RAfZyh7RJzJfVzT98KUYQQ==}
+  '@hey-api/openapi-ts@0.97.3':
+    resolution: {integrity: sha512-4sR6/E/POuy7aPZW9DDjhObzZCq7eSJWiW0+epXeKNczoTWEwdOyWFy9Ca/CnXYlZ3oJsrv0ZD0OO+YuczT7CA==}
     engines: {node: '>=22.13.0'}
     hasBin: true
     peerDependencies:
       typescript: '>=5.5.3 || >=6.0.0 || 6.0.1-rc'
 
-  '@hey-api/shared@0.4.4':
-    resolution: {integrity: sha512-UZgaQNEdo/OSGLeNXhSv0VQTHQQm5Q2mHOuoYhFPJkNvLVrz7KZtGdKR8O4QPrhyblshxY+caJli08WKM0gREg==}
+  '@hey-api/shared@0.4.5':
+    resolution: {integrity: sha512-au4eHpBXAe1du0iMp6ESYuEaMS2jsoEyrbcT246btRhI9rMeQFEs7ZjtcMGXGsxhpaR38A8cPGNHx7QOrWAdMw==}
     engines: {node: '>=22.13.0'}
 
   '@hey-api/spec-types@0.2.0':
@@ -331,8 +331,8 @@ packages:
     resolution: {integrity: sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==}
     engines: {node: '>= 20'}
 
-  '@octokit/request@10.0.9':
-    resolution: {integrity: sha512-o8Bi3f608eyM+7BmBiUWxFsdjLb3/ym1cQek5LZOv9KkZcxRrHCPhhRzm6xjO6HVZ85ItD6+sTsjxo821SVa/A==}
+  '@octokit/request@10.0.10':
+    resolution: {integrity: sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==}
     engines: {node: '>= 20'}
 
   '@octokit/types@16.0.0':
@@ -495,12 +495,12 @@ packages:
     resolution: {integrity: sha512-PpIdj5Wje0T7ktxY8EUzBWLU0+mGGQHznT8nlQxTMnRhWLNYsm6HvSZDXLtMi+86yqvTuf7loJy6JvLBDzHGAA==}
     engines: {node: ^16.20 || ^18.18 || >= 20.17}
 
-  '@stoplight/spectral-ruleset-migrator@1.12.0':
-    resolution: {integrity: sha512-KINmItys8OhdmjudgcIu7siuxQ4hDdbMsTPW/UkXhoiEosiwok1xAyaYLBfckH9zH85TZBkDDbIbsiMoDCIxBw==}
+  '@stoplight/spectral-ruleset-migrator@1.12.1':
+    resolution: {integrity: sha512-IUEbDmmTro0oF6VoAtrUySRV/b6bvYmV7wV6lB99f0Ym5lF9M2DXcgPLo7VMbKTPjCOQcaBzWRnIMXAyLjIRMA==}
     engines: {node: ^16.20 || ^18.18 || >= 20.17}
 
-  '@stoplight/spectral-rulesets@1.22.2':
-    resolution: {integrity: sha512-JsaNqtxBRfjKTCgQJK+LoOyDhzm9Hhw9kV9U3NalsQMH5ERBJw6IVhYyCZtgHBc5FhjXao2iJnnDfGta07M4wQ==}
+  '@stoplight/spectral-rulesets@1.22.3':
+    resolution: {integrity: sha512-CDkXEsrA1OOQPmF0VE92zira+eSI411s7hyIdfVeS/91BrNz3Y5HJgnwWFbh2abKVJ2rNciOzBPyGar+xfiFKA==}
     engines: {node: ^16.20 || ^18.18 || >= 20.17}
 
   '@stoplight/spectral-runtime@1.1.5':
@@ -561,8 +561,8 @@ packages:
   '@types/node@20.19.41':
     resolution: {integrity: sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==}
 
-  '@types/node@25.8.0':
-    resolution: {integrity: sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==}
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -718,8 +718,8 @@ packages:
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
-  brace-expansion@1.1.14:
-    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+  brace-expansion@1.1.15:
+    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
 
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
@@ -1078,10 +1078,6 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
-  es-object-atoms@1.1.1:
-    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
-    engines: {node: '>= 0.4'}
-
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
@@ -1094,8 +1090,8 @@ packages:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
-  es-toolkit@1.46.1:
-    resolution: {integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==}
+  es-toolkit@1.47.0:
+    resolution: {integrity: sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==}
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -1155,9 +1151,6 @@ packages:
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
-
-  fast-content-type-parse@3.0.0:
-    resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1239,10 +1232,6 @@ packages:
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
-
-  fs-extra@11.3.4:
-    resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
-    engines: {node: '>=14.14'}
 
   fs-extra@11.3.5:
     resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
@@ -1405,8 +1394,8 @@ packages:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
-  hosted-git-info@9.0.2:
-    resolution: {integrity: sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==}
+  hosted-git-info@9.0.3:
+    resolution: {integrity: sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
   hpagent@1.2.0:
@@ -1758,10 +1747,6 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
-  lru-cache@11.3.5:
-    resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
-    engines: {node: 20 || >=22}
-
   lru-cache@11.5.0:
     resolution: {integrity: sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==}
     engines: {node: 20 || >=22}
@@ -1894,8 +1879,8 @@ packages:
     resolution: {integrity: sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  normalize-url@9.0.0:
-    resolution: {integrity: sha512-z9nC87iaZXXySbWWtTHfCFJyFvKaUAW6lODhikG7ILSbVgmwuFjUqkgnheHvAUcGedO29e2QGBRXMUD64aurqQ==}
+  normalize-url@9.0.1:
+    resolution: {integrity: sha512-ARftfC5HdUNu9jJeL8pHj8debUIHA2b91FizCoMzY4lG6dDX13jdvTK0TBe24IBDRf2HvJSzzwEPvmbkQWHRSg==}
     engines: {node: '>=20'}
 
   npm-run-path@4.0.1:
@@ -1910,8 +1895,8 @@ packages:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
     engines: {node: '>=18'}
 
-  npm@11.13.0:
-    resolution: {integrity: sha512-cRmhaghDWA1lFgl3Ug4/VxDJdPBK/U+tNtnrl9kXunFqhWw1x4xL5txkNn7qzPuVfvXOmXyjHpMwsuk2uisbkg==}
+  npm@11.15.0:
+    resolution: {integrity: sha512-+k0tk7lRnpMUPnC7kTuU/yrV/mnFoPhJQ75VfLtZ6fwbzOVXaPsTE/Il9Pn1DHi482byMyqkHv/XsQ76mNjXLw==}
     engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
     bundledDependencies:
@@ -2323,11 +2308,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.8.0:
-    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.8.1:
     resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
     engines: {node: '>=10'}
@@ -2544,8 +2524,8 @@ packages:
     resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
     engines: {node: '>=12'}
 
-  tinyexec@1.1.2:
-    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+  tinyexec@1.2.2:
+    resolution: {integrity: sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==}
     engines: {node: '>=18'}
 
   tinyglobby@0.2.16:
@@ -2645,12 +2625,12 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@6.25.0:
-    resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
+  undici@6.26.0:
+    resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
     engines: {node: '>=18.17'}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.26.0:
+    resolution: {integrity: sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==}
     engines: {node: '>=20.18.1'}
 
   unicode-emoji-modifier-base@1.0.0:
@@ -2724,8 +2704,8 @@ packages:
     resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
     engines: {node: '>= 0.4'}
 
-  which-typed-array@1.1.20:
-    resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
+  which-typed-array@1.1.21:
+    resolution: {integrity: sha512-zbRA8cVm6io/d5W8uIe2hblzN76/Wm3v/yiythQvr+dpBWeqhPSWIDNj4zOyHi4zKbMK6DN34Xsr9jPHJERAEw==}
     engines: {node: '>= 0.4'}
 
   which@2.0.2:
@@ -2805,7 +2785,7 @@ snapshots:
   '@actions/http-client@4.0.1':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.25.0
+      undici: 6.26.0
 
   '@actions/io@3.0.2': {}
 
@@ -2813,27 +2793,27 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@babel/code-frame@7.29.0':
+  '@babel/code-frame@7.29.7':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/helper-validator-identifier@7.28.5': {}
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@borewit/text-codec@0.2.2': {}
 
   '@colors/colors@1.5.0':
     optional: true
 
-  '@commitlint/cli@21.0.1(@types/node@25.8.0)(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(typescript@6.0.2)':
+  '@commitlint/cli@21.0.1(@types/node@25.9.1)(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(typescript@6.0.2)':
     dependencies:
       '@commitlint/format': 21.0.1
       '@commitlint/lint': 21.0.1
-      '@commitlint/load': 21.0.1(@types/node@25.8.0)(typescript@6.0.2)
+      '@commitlint/load': 21.0.1(@types/node@25.9.1)(typescript@6.0.2)
       '@commitlint/read': 21.0.1(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)
       '@commitlint/types': 21.0.1
-      tinyexec: 1.1.2
+      tinyexec: 1.2.2
       yargs: 18.0.0
     transitivePeerDependencies:
       - '@types/node'
@@ -2854,7 +2834,7 @@ snapshots:
   '@commitlint/ensure@21.0.1':
     dependencies:
       '@commitlint/types': 21.0.1
-      es-toolkit: 1.46.1
+      es-toolkit: 1.47.0
 
   '@commitlint/execute-rule@21.0.1': {}
 
@@ -2875,15 +2855,15 @@ snapshots:
       '@commitlint/rules': 21.0.1
       '@commitlint/types': 21.0.1
 
-  '@commitlint/load@21.0.1(@types/node@25.8.0)(typescript@6.0.2)':
+  '@commitlint/load@21.0.1(@types/node@25.9.1)(typescript@6.0.2)':
     dependencies:
       '@commitlint/config-validator': 21.0.1
       '@commitlint/execute-rule': 21.0.1
       '@commitlint/resolve-extends': 21.0.1
       '@commitlint/types': 21.0.1
       cosmiconfig: 9.0.1(typescript@6.0.2)
-      cosmiconfig-typescript-loader: 6.3.0(@types/node@25.8.0)(cosmiconfig@9.0.1(typescript@6.0.2))(typescript@6.0.2)
-      es-toolkit: 1.46.1
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@25.9.1)(cosmiconfig@9.0.1(typescript@6.0.2))(typescript@6.0.2)
+      es-toolkit: 1.47.0
       is-plain-obj: 4.1.0
       picocolors: 1.1.1
     transitivePeerDependencies:
@@ -2903,7 +2883,7 @@ snapshots:
       '@commitlint/top-level': 21.0.1
       '@commitlint/types': 21.0.1
       git-raw-commits: 5.0.1(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)
-      tinyexec: 1.1.2
+      tinyexec: 1.2.2
     transitivePeerDependencies:
       - conventional-commits-filter
       - conventional-commits-parser
@@ -2912,7 +2892,7 @@ snapshots:
     dependencies:
       '@commitlint/config-validator': 21.0.1
       '@commitlint/types': 21.0.1
-      es-toolkit: 1.46.1
+      es-toolkit: 1.47.0
       global-directory: 5.0.0
       resolve-from: 5.0.0
 
@@ -2943,7 +2923,7 @@ snapshots:
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.4.0
 
-  '@hey-api/codegen-core@0.8.1':
+  '@hey-api/codegen-core@0.8.2':
     dependencies:
       '@hey-api/types': 0.1.4
       ansi-colors: 4.1.3
@@ -2958,11 +2938,11 @@ snapshots:
       '@types/json-schema': 7.0.15
       js-yaml: 4.1.1
 
-  '@hey-api/openapi-ts@0.97.2(typescript@6.0.2)':
+  '@hey-api/openapi-ts@0.97.3(typescript@6.0.2)':
     dependencies:
-      '@hey-api/codegen-core': 0.8.1
+      '@hey-api/codegen-core': 0.8.2
       '@hey-api/json-schema-ref-parser': 1.4.2
-      '@hey-api/shared': 0.4.4
+      '@hey-api/shared': 0.4.5
       '@hey-api/spec-types': 0.2.0
       '@hey-api/types': 0.1.4
       '@lukeed/ms': 2.0.2
@@ -2974,9 +2954,9 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@hey-api/shared@0.4.4':
+  '@hey-api/shared@0.4.5':
     dependencies:
-      '@hey-api/codegen-core': 0.8.1
+      '@hey-api/codegen-core': 0.8.2
       '@hey-api/json-schema-ref-parser': 1.4.2
       '@hey-api/spec-types': 0.2.0
       '@hey-api/types': 0.1.4
@@ -3100,7 +3080,7 @@ snapshots:
     dependencies:
       '@octokit/auth-token': 6.0.0
       '@octokit/graphql': 9.0.3
-      '@octokit/request': 10.0.9
+      '@octokit/request': 10.0.10
       '@octokit/request-error': 7.1.0
       '@octokit/types': 16.0.0
       before-after-hook: 4.0.0
@@ -3113,7 +3093,7 @@ snapshots:
 
   '@octokit/graphql@9.0.3':
     dependencies:
-      '@octokit/request': 10.0.9
+      '@octokit/request': 10.0.10
       '@octokit/types': 16.0.0
       universal-user-agent: 7.0.3
 
@@ -3141,13 +3121,12 @@ snapshots:
     dependencies:
       '@octokit/types': 16.0.0
 
-  '@octokit/request@10.0.9':
+  '@octokit/request@10.0.10':
     dependencies:
       '@octokit/endpoint': 11.0.3
       '@octokit/request-error': 7.1.0
       '@octokit/types': 16.0.0
       content-type: 2.0.0
-      fast-content-type-parse: 3.0.0
       json-with-bigint: 3.5.8
       universal-user-agent: 7.0.3
 
@@ -3220,7 +3199,7 @@ snapshots:
     dependencies:
       '@semantic-release/error': 3.0.0
       aggregate-error: 3.1.0
-      fs-extra: 11.3.4
+      fs-extra: 11.3.5
       lodash: 4.18.1
       semantic-release: 25.0.3(typescript@6.0.2)
 
@@ -3286,7 +3265,7 @@ snapshots:
       p-filter: 4.1.0
       semantic-release: 25.0.3(typescript@6.0.2)
       tinyglobby: 0.2.16
-      undici: 7.25.0
+      undici: 7.26.0
       url-join: 5.0.0
     transitivePeerDependencies:
       - supports-color
@@ -3298,16 +3277,16 @@ snapshots:
       aggregate-error: 5.0.0
       env-ci: 11.2.0
       execa: 9.6.1
-      fs-extra: 11.3.4
+      fs-extra: 11.3.5
       lodash-es: 4.18.1
       nerf-dart: 1.0.0
-      normalize-url: 9.0.0
-      npm: 11.13.0
+      normalize-url: 9.0.1
+      npm: 11.15.0
       rc: 1.2.8
       read-pkg: 10.1.0
       registry-auth-token: 5.1.1
       semantic-release: 25.0.3(typescript@6.0.2)
-      semver: 7.7.4
+      semver: 7.8.1
       tempy: 3.2.0
 
   '@semantic-release/release-notes-generator@14.1.1(semantic-release@25.0.3(typescript@6.0.2))':
@@ -3382,8 +3361,8 @@ snapshots:
       '@stoplight/spectral-parsers': 1.0.5
       '@stoplight/spectral-ref-resolver': 1.0.5
       '@stoplight/spectral-ruleset-bundler': 1.7.0
-      '@stoplight/spectral-ruleset-migrator': 1.12.0
-      '@stoplight/spectral-rulesets': 1.22.2
+      '@stoplight/spectral-ruleset-migrator': 1.12.1
+      '@stoplight/spectral-rulesets': 1.22.3
       '@stoplight/spectral-runtime': 1.1.5
       '@stoplight/types': 13.20.0
       chalk: 4.1.2
@@ -3492,11 +3471,11 @@ snapshots:
       '@stoplight/spectral-functions': 1.10.2
       '@stoplight/spectral-parsers': 1.0.5
       '@stoplight/spectral-ref-resolver': 1.0.5
-      '@stoplight/spectral-ruleset-migrator': 1.12.0
-      '@stoplight/spectral-rulesets': 1.22.2
+      '@stoplight/spectral-ruleset-migrator': 1.12.1
+      '@stoplight/spectral-rulesets': 1.22.3
       '@stoplight/spectral-runtime': 1.1.5
       '@stoplight/types': 13.20.0
-      '@types/node': 25.8.0
+      '@types/node': 25.9.1
       pony-cause: 1.1.1
       rollup: 2.80.0
       tslib: 2.8.1
@@ -3504,7 +3483,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@stoplight/spectral-ruleset-migrator@1.12.0':
+  '@stoplight/spectral-ruleset-migrator@1.12.1':
     dependencies:
       '@stoplight/json': 3.21.7
       '@stoplight/ordered-object-literal': 1.0.5
@@ -3513,7 +3492,7 @@ snapshots:
       '@stoplight/spectral-runtime': 1.1.5
       '@stoplight/types': 13.20.0
       '@stoplight/yaml': 4.2.3
-      '@types/node': 25.8.0
+      '@types/node': 25.9.1
       ajv: 8.20.0
       ast-types: 0.14.2
       astring: 1.9.0
@@ -3523,7 +3502,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@stoplight/spectral-rulesets@1.22.2':
+  '@stoplight/spectral-rulesets@1.22.3':
     dependencies:
       '@asyncapi/specs': 6.11.1
       '@stoplight/better-ajv-errors': 1.0.3(ajv@8.20.0)
@@ -3599,7 +3578,7 @@ snapshots:
 
   '@types/es-aggregate-error@1.0.6':
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 25.9.1
 
   '@types/estree@0.0.39': {}
 
@@ -3611,13 +3590,13 @@ snapshots:
 
   '@types/mute-stream@0.0.4':
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 20.19.41
 
   '@types/node@20.19.41':
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@25.8.0':
+  '@types/node@25.9.1':
     dependencies:
       undici-types: 7.24.6
 
@@ -3759,7 +3738,7 @@ snapshots:
 
   bottleneck@2.19.5: {}
 
-  brace-expansion@1.1.14:
+  brace-expansion@1.1.15:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -3950,7 +3929,7 @@ snapshots:
       conventional-commits-filter: 5.0.0
       handlebars: 4.7.9
       meow: 13.2.0
-      semver: 7.8.0
+      semver: 7.8.1
 
   conventional-commits-filter@5.0.0: {}
 
@@ -3963,9 +3942,9 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  cosmiconfig-typescript-loader@6.3.0(@types/node@25.8.0)(cosmiconfig@9.0.1(typescript@6.0.2))(typescript@6.0.2):
+  cosmiconfig-typescript-loader@6.3.0(@types/node@25.9.1)(cosmiconfig@9.0.1(typescript@6.0.2))(typescript@6.0.2):
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 25.9.1
       cosmiconfig: 9.0.1(typescript@6.0.2)
       jiti: 2.6.1
       typescript: 6.0.2
@@ -4113,7 +4092,7 @@ snapshots:
       data-view-byte-offset: 1.0.1
       es-define-property: 1.0.1
       es-errors: 1.3.0
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
       es-set-tostringtag: 2.1.0
       es-to-primitive: 1.3.0
       function.prototype.name: 1.1.8
@@ -4156,7 +4135,7 @@ snapshots:
       typed-array-byte-offset: 1.0.4
       typed-array-length: 1.0.7
       unbox-primitive: 1.1.0
-      which-typed-array: 1.1.20
+      which-typed-array: 1.1.21
 
   es-aggregate-error@1.0.14:
     dependencies:
@@ -4172,10 +4151,6 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
-
-  es-object-atoms@1.1.1:
-    dependencies:
-      es-errors: 1.3.0
 
   es-object-atoms@1.1.2:
     dependencies:
@@ -4194,7 +4169,7 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
-  es-toolkit@1.46.1: {}
+  es-toolkit@1.47.0: {}
 
   escalade@3.2.0: {}
 
@@ -4264,8 +4239,6 @@ snapshots:
   expr-eval-fork@3.0.3: {}
 
   exsolve@1.0.8: {}
-
-  fast-content-type-parse@3.0.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -4347,12 +4320,6 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
-  fs-extra@11.3.4:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.2.1
-      universalify: 2.0.1
-
   fs-extra@11.3.5:
     dependencies:
       graceful-fs: 4.2.11
@@ -4401,7 +4368,7 @@ snapshots:
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
 
   get-source@2.0.12:
     dependencies:
@@ -4529,9 +4496,9 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
 
-  hosted-git-info@9.0.2:
+  hosted-git-info@9.0.3:
     dependencies:
-      lru-cache: 11.3.5
+      lru-cache: 11.5.0
 
   hpagent@1.2.0: {}
 
@@ -4728,7 +4695,7 @@ snapshots:
 
   is-typed-array@1.1.15:
     dependencies:
-      which-typed-array: 1.1.20
+      which-typed-array: 1.1.21
 
   is-unicode-supported@2.1.0: {}
 
@@ -4837,8 +4804,6 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lru-cache@11.3.5: {}
-
   lru-cache@11.5.0: {}
 
   lru-cache@7.18.3: {}
@@ -4899,7 +4864,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.14
+      brace-expansion: 1.1.15
 
   minimist@1.2.8: {}
 
@@ -4955,11 +4920,11 @@ snapshots:
 
   normalize-package-data@8.0.0:
     dependencies:
-      hosted-git-info: 9.0.2
+      hosted-git-info: 9.0.3
       semver: 7.8.1
       validate-npm-package-license: 3.0.4
 
-  normalize-url@9.0.0: {}
+  normalize-url@9.0.1: {}
 
   npm-run-path@4.0.1:
     dependencies:
@@ -4974,7 +4939,7 @@ snapshots:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
 
-  npm@11.13.0: {}
+  npm@11.15.0: {}
 
   object-assign@4.1.1: {}
 
@@ -4987,7 +4952,7 @@ snapshots:
       call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
       has-symbols: 1.1.0
       object-keys: 1.1.1
 
@@ -5078,14 +5043,14 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
   parse-json@8.3.0:
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       index-to-position: 1.2.0
       type-fest: 4.41.0
 
@@ -5331,7 +5296,7 @@ snapshots:
       get-stream: 6.0.1
       git-log-parser: 1.2.1
       hook-std: 4.0.0
-      hosted-git-info: 9.0.2
+      hosted-git-info: 9.0.3
       import-from-esm: 2.0.0
       lodash-es: 4.18.1
       marked: 15.0.12
@@ -5341,7 +5306,7 @@ snapshots:
       p-reduce: 3.0.0
       read-package-up: 12.0.0
       resolve-from: 5.0.0
-      semver: 7.7.4
+      semver: 7.8.1
       signale: 1.4.0
       yargs: 18.0.0
     transitivePeerDependencies:
@@ -5351,8 +5316,6 @@ snapshots:
   semver-regex@4.0.5: {}
 
   semver@7.7.4: {}
-
-  semver@7.8.0: {}
 
   semver@7.8.1: {}
 
@@ -5376,7 +5339,7 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
 
   shebang-command@2.0.0:
     dependencies:
@@ -5501,7 +5464,7 @@ snapshots:
       define-data-property: 1.1.4
       define-properties: 1.2.1
       es-abstract: 1.24.2
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
       has-property-descriptors: 1.0.2
 
   string.prototype.trimend@1.0.9:
@@ -5509,13 +5472,13 @@ snapshots:
       call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
 
   string.prototype.trimstart@1.0.8:
     dependencies:
       call-bind: 1.0.9
       define-properties: 1.2.1
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
 
   string_decoder@1.1.1:
     dependencies:
@@ -5598,7 +5561,7 @@ snapshots:
     dependencies:
       convert-hrtime: 5.0.0
 
-  tinyexec@1.1.2: {}
+  tinyexec@1.2.2: {}
 
   tinyglobby@0.2.16:
     dependencies:
@@ -5694,9 +5657,9 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@6.25.0: {}
+  undici@6.26.0: {}
 
-  undici@7.25.0: {}
+  undici@7.26.0: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 
@@ -5767,7 +5730,7 @@ snapshots:
       isarray: 2.0.5
       which-boxed-primitive: 1.1.1
       which-collection: 1.0.2
-      which-typed-array: 1.1.20
+      which-typed-array: 1.1.21
 
   which-collection@1.0.2:
     dependencies:
@@ -5776,7 +5739,7 @@ snapshots:
       is-weakmap: 2.0.2
       is-weakset: 2.0.4
 
-  which-typed-array@1.1.20:
+  which-typed-array@1.1.21:
     dependencies:
       available-typed-arrays: 1.0.7
       call-bind: 1.0.9

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -9,16 +9,10 @@ info:
     url: https://github.com/budget-buddy-org/budget-buddy-contracts
 
 servers:
-  - url: "{scheme}://{host}"
-    description: Configurable Budget Buddy API server
-    variables:
-      scheme:
-        default: http
-        enum:
-          - http
-          - https
-      host:
-        default: localhost:8080
+  - url: https://budgetbuddy.glebremniov.keenetic.link
+    description: Production (self-hosted on Raspberry Pi behind nginx).
+  - url: http://localhost:8080
+    description: Local development (`./gradlew bootRun --args='--spring.profiles.active=dev'`).
 
 tags:
   - name: categories
@@ -98,20 +92,8 @@ paths:
         `excludedTransactionCount` so the UI can surface an informational note.
       operationId: getCategoriesSummary
       parameters:
-        - name: month
-          in: query
-          required: true
-          description: Calendar month to summarise, formatted YYYY-MM. Interpreted in UTC.
-          schema:
-            type: string
-            pattern: "^\\d{4}-(0[1-9]|1[0-2])$"
-            example: "2026-05"
-        - name: currency
-          in: query
-          required: true
-          description: ISO 4217 three-letter currency code. Only transactions in this currency contribute to `spent`.
-          schema:
-            $ref: "#/components/schemas/Currency"
+        - $ref: "#/components/parameters/monthQuery"
+        - $ref: "#/components/parameters/currencyQuery"
       responses:
         "200":
           description: Per-category spending summary for the requested month and currency
@@ -231,20 +213,8 @@ paths:
         are reflected in `excludedTransactionCount` so the UI can surface an informational note.
       operationId: getTransactionsSummary
       parameters:
-        - name: month
-          in: query
-          required: true
-          description: Calendar month to summarise, formatted YYYY-MM. Interpreted in UTC.
-          schema:
-            type: string
-            pattern: "^\\d{4}-(0[1-9]|1[0-2])$"
-            example: "2026-05"
-        - name: currency
-          in: query
-          required: true
-          description: ISO 4217 three-letter currency code. Only transactions in this currency contribute to income/expense.
-          schema:
-            $ref: "#/components/schemas/Currency"
+        - $ref: "#/components/parameters/monthQuery"
+        - $ref: "#/components/parameters/currencyQuery"
       responses:
         "200":
           description: Monthly summary for the requested month and currency
@@ -283,25 +253,16 @@ paths:
         - name: from
           in: query
           required: true
-          description: First calendar month in the range (inclusive), formatted YYYY-MM. Interpreted in UTC.
+          description: First calendar month in the range (inclusive).
           schema:
-            type: string
-            pattern: "^\\d{4}-(0[1-9]|1[0-2])$"
-            example: "2025-12"
+            $ref: "#/components/schemas/Month"
         - name: to
           in: query
           required: true
-          description: Last calendar month in the range (inclusive), formatted YYYY-MM. Must be greater than or equal to `from`, and no more than 24 months after `from`.
+          description: Last calendar month in the range (inclusive). Must be greater than or equal to `from`, and no more than 24 months after `from`.
           schema:
-            type: string
-            pattern: "^\\d{4}-(0[1-9]|1[0-2])$"
-            example: "2026-05"
-        - name: currency
-          in: query
-          required: true
-          description: ISO 4217 three-letter currency code. Only transactions in this currency contribute to income/expense.
-          schema:
-            $ref: "#/components/schemas/Currency"
+            $ref: "#/components/schemas/Month"
+        - $ref: "#/components/parameters/currencyQuery"
       responses:
         "200":
           description: One `MonthlySummary` per calendar month in the requested range, oldest first.
@@ -349,10 +310,9 @@ paths:
             minimum: 1
         - name: categoryId
           in: query
-          description: Filter by category
+          description: Filter to transactions assigned to this category.
           schema:
-            type: string
-            format: uuid
+            $ref: "#/components/schemas/Uuid"
         - name: start
           in: query
           description: Inclusive start date
@@ -557,6 +517,27 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /v1/users/me/data:
+    delete:
+      tags: [ users ]
+      summary: Clear current user's data
+      description: |
+        Permanently deletes every category and transaction owned by the authenticated user, while
+        leaving the account itself intact. Preferences and per-client settings are preserved; the
+        identity provider is not contacted and the bearer token remains valid.
+
+        Intended for "start over" flows where the user wants to wipe their financial history without
+        losing their sign-in or app configuration. The operation is idempotent — a second call on an
+        already-empty account returns 204.
+      operationId: clearCurrentUserData
+      responses:
+        "204":
+          description: Data cleared
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
   /v1/users/me/preferences:
     get:
       tags: [ users ]
@@ -736,32 +717,41 @@ components:
       name: categoryId
       in: path
       required: true
-      description: Category UUID
+      description: Category UUID.
       schema:
-        type: string
-        format: uuid
+        $ref: "#/components/schemas/Uuid"
 
     transactionId:
       name: transactionId
       in: path
       required: true
-      description: Transaction UUID
+      description: Transaction UUID.
       schema:
-        type: string
-        format: uuid
+        $ref: "#/components/schemas/Uuid"
 
     clientId:
       name: clientId
       in: path
       required: true
-      description: |
-        Client identifier used to scope per-client settings. Conventional values include `web`,
-        `mobile-ios`, `mobile-android`, `telegram-bot`. Lowercase letters, digits, and hyphens only;
-        up to 32 characters.
+      description: Client this settings row belongs to. See the `ClientId` schema for the allowed format.
       schema:
-        type: string
-        pattern: "^[a-z0-9-]{1,32}$"
-        example: web
+        $ref: "#/components/schemas/ClientId"
+
+    monthQuery:
+      name: month
+      in: query
+      required: true
+      description: Calendar month to summarise, formatted YYYY-MM. Interpreted in UTC.
+      schema:
+        $ref: "#/components/schemas/Month"
+
+    currencyQuery:
+      name: currency
+      in: query
+      required: true
+      description: ISO 4217 three-letter currency code. Only transactions in this currency contribute to the response totals.
+      schema:
+        $ref: "#/components/schemas/Currency"
 
     page:
       name: page
@@ -784,7 +774,11 @@ components:
 
   responses:
     BadRequest:
-      description: Bad request
+      description: |
+        Bad request. When the failure is per-field validation (e.g. unknown field, value out of
+        bounds), the response `Problem` has `errors[]` populated with one `FieldError` per offending
+        field. For other 400s (semantic validation, cross-field rules), `errors[]` is omitted and
+        the human-readable summary is in `detail`.
       content:
         application/problem+json:
           schema:
@@ -814,35 +808,29 @@ components:
   schemas:
     Category:
       type: object
-      required: [ id, name ]
+      required: [ id, name, monthlyBudget ]
       properties:
         id:
-          type: string
-          format: uuid
           description: Unique identifier for the category.
-          example: 550e8400-e29b-41d4-a716-446655440000
+          allOf:
+            - $ref: "#/components/schemas/Uuid"
         name:
           type: string
-          description: Human-readable name of the category.
+          description: Human-readable name of the category (1–255 characters).
+          minLength: 1
+          maxLength: 255
           example: Groceries
         monthlyBudget:
           type: [ integer, "null" ]
           format: int64
           minimum: 0
-          description: Monthly spending budget for this category, in minor units (e.g. 50000 = €500.00). Null means no budget set.
+          description: Monthly spending budget for this category, in minor units (e.g. 50000 = €500.00). Null when no budget is set.
           example: 50000
-        createdAt:
-          type: string
-          format: date-time
-          description: ISO 8601 timestamp when the category was created.
-        updatedAt:
-          type: string
-          format: date-time
-          description: ISO 8601 timestamp when the category was last updated.
 
     CategoryWrite:
       type: object
-      required: [ name ]
+      additionalProperties: false
+      required: [ name, monthlyBudget ]
       properties:
         name:
           type: string
@@ -854,11 +842,12 @@ components:
           type: [ integer, "null" ]
           format: int64
           minimum: 0
-          description: Monthly spending budget for this category, in minor units. Omit or pass null for no budget.
+          description: Monthly spending budget for this category, in minor units. Pass null for no budget.
           example: 50000
 
     CategoryUpdate:
       type: object
+      additionalProperties: false
       description: Patch request — only provided fields are updated. At least one field must be provided.
       minProperties: 1
       properties:
@@ -875,13 +864,32 @@ components:
           description: New monthly budget in minor units. Pass null to clear an existing budget.
           example: 75000
 
+    Uuid:
+      type: string
+      format: uuid
+      description: RFC 4122 UUID, lowercase hex with hyphens.
+      example: 550e8400-e29b-41d4-a716-446655440000
+
+    Month:
+      type: string
+      description: Calendar month formatted as YYYY-MM. Interpreted in UTC.
+      pattern: "^\\d{4}-(0[1-9]|1[0-2])$"
+      example: "2026-05"
+
     Currency:
       type: string
       description: ISO 4217 three-letter currency code (uppercase letters only).
       pattern: "^[A-Z]{3}$"
-      minLength: 3
-      maxLength: 3
       example: EUR
+
+    ClientId:
+      type: string
+      description: |
+        Client identifier used to scope per-client settings. Conventional values include `web`,
+        `mobile-ios`, `mobile-android`, `telegram-bot`. Lowercase letters, digits, and hyphens only;
+        up to 32 characters.
+      pattern: "^[a-z0-9-]{1,32}$"
+      example: web
 
     TransactionType:
       type: string
@@ -892,20 +900,21 @@ components:
 
     Transaction:
       type: object
-      required: [ id, categoryId, amount, type, currency, date ]
+      required: [ id, categoryId, amount, type, currency, date, description ]
       properties:
         id:
-          type: string
-          format: uuid
           description: Unique identifier for the transaction.
+          allOf:
+            - $ref: "#/components/schemas/Uuid"
         categoryId:
-          type: string
-          format: uuid
           description: UUID of the category this transaction belongs to.
+          allOf:
+            - $ref: "#/components/schemas/Uuid"
         amount:
           type: integer
           format: int64
-          description: Amount in minor units (e.g. 1299 = €12.99).
+          description: Amount in minor units (e.g. 1299 = €12.99). Always at least 1.
+          minimum: 1
           example: 1299
         type:
           description: Whether this transaction is an outgoing expense or incoming income.
@@ -921,27 +930,21 @@ components:
           description: Date on which the transaction occurred (YYYY-MM-DD).
           example: 2026-03-08
         description:
-          type: string
-          description: Optional free-text note for the transaction (up to 255 characters).
+          type: [ string, "null" ]
+          description: Free-text note for the transaction (1–255 characters). Null when no note is set.
+          minLength: 1
           maxLength: 255
           example: Coffee
-        createdAt:
-          type: string
-          format: date-time
-          description: ISO 8601 timestamp when the transaction record was created.
-        updatedAt:
-          type: string
-          format: date-time
-          description: ISO 8601 timestamp when the transaction record was last updated.
 
     TransactionWrite:
       type: object
-      required: [ categoryId, amount, type, currency, date ]
+      additionalProperties: false
+      required: [ categoryId, amount, type, currency, date, description ]
       properties:
         categoryId:
-          type: string
-          format: uuid
           description: UUID of the category this transaction belongs to.
+          allOf:
+            - $ref: "#/components/schemas/Uuid"
         amount:
           type: integer
           format: int64
@@ -961,19 +964,21 @@ components:
           format: date
           description: Date on which the transaction occurred (YYYY-MM-DD).
         description:
-          type: string
-          description: Optional free-text note for the transaction (up to 255 characters).
+          type: [ string, "null" ]
+          description: Free-text note for the transaction (1–255 characters). Pass null for no note.
+          minLength: 1
           maxLength: 255
 
     TransactionUpdate:
       type: object
+      additionalProperties: false
       description: Patch request — only provided fields are updated. At least one field must be provided.
       minProperties: 1
       properties:
         categoryId:
-          type: string
-          format: uuid
           description: UUID of the category to reassign this transaction to.
+          allOf:
+            - $ref: "#/components/schemas/Uuid"
         amount:
           type: integer
           format: int64
@@ -993,7 +998,8 @@ components:
           description: New transaction date (YYYY-MM-DD).
         description:
           type: [ string, "null" ]
-          description: Updated free-text note (up to 255 characters). Pass null to clear the existing note.
+          description: Updated free-text note (1–255 characters). Pass null to clear the existing note.
+          minLength: 1
           maxLength: 255
 
     PaginationMeta:
@@ -1027,15 +1033,17 @@ components:
 
     CategorySpendingRow:
       type: object
-      required: [ categoryId, categoryName, spent, transactionCount, excludedTransactionCount ]
+      required: [ categoryId, categoryName, monthlyBudget, spent, transactionCount, excludedTransactionCount ]
       properties:
         categoryId:
-          type: string
-          format: uuid
           description: UUID of the category this row summarises.
+          allOf:
+            - $ref: "#/components/schemas/Uuid"
         categoryName:
           type: string
-          description: Human-readable name of the category at the time of the response.
+          description: Human-readable name of the category at the time of the response (1–255 characters).
+          minLength: 1
+          maxLength: 255
         monthlyBudget:
           type: [ integer, "null" ]
           format: int64
@@ -1064,10 +1072,9 @@ components:
       required: [ month, currency, items ]
       properties:
         month:
-          type: string
-          pattern: "^\\d{4}-(0[1-9]|1[0-2])$"
-          description: Calendar month echoed back from the request, formatted YYYY-MM.
-          example: "2026-05"
+          description: Calendar month echoed back from the request.
+          allOf:
+            - $ref: "#/components/schemas/Month"
         currency:
           description: ISO 4217 currency code echoed back from the request.
           allOf:
@@ -1083,10 +1090,9 @@ components:
       required: [ month, currency, income, expense, balance, incomeCount, expenseCount, excludedTransactionCount ]
       properties:
         month:
-          type: string
-          pattern: "^\\d{4}-(0[1-9]|1[0-2])$"
-          description: Calendar month this summary covers, formatted YYYY-MM.
-          example: "2026-05"
+          description: Calendar month this summary covers.
+          allOf:
+            - $ref: "#/components/schemas/Month"
         currency:
           description: ISO 4217 currency code echoed back from the request.
           allOf:
@@ -1217,17 +1223,10 @@ components:
           description: Preferred IANA timezone.
           allOf:
             - $ref: "#/components/schemas/Timezone"
-        createdAt:
-          type: string
-          format: date-time
-          description: ISO 8601 timestamp when the preferences row was first created.
-        updatedAt:
-          type: string
-          format: date-time
-          description: ISO 8601 timestamp when the preferences row was last updated.
 
     UserPreferencesWrite:
       type: object
+      additionalProperties: false
       description: Full replacement of the user's global preferences (PUT semantics).
       required: [ language, currency, timezone ]
       properties:
@@ -1246,6 +1245,7 @@ components:
 
     UserPreferencesUpdate:
       type: object
+      additionalProperties: false
       description: Patch request — only provided fields are updated. At least one field must be provided.
       minProperties: 1
       properties:
@@ -1270,21 +1270,13 @@ components:
       required: [ id, preferences ]
       properties:
         id:
-          type: string
-          format: uuid
           description: The local Budget Buddy user UUID, derived from the OIDC subject on first login. Stable across sessions and used as the owner of all user-scoped resources.
+          allOf:
+            - $ref: "#/components/schemas/Uuid"
         preferences:
           description: The user's current global preferences (server defaults if none have been stored).
           allOf:
             - $ref: "#/components/schemas/UserPreferences"
-        createdAt:
-          type: string
-          format: date-time
-          description: ISO 8601 timestamp when the local user record was first provisioned.
-        updatedAt:
-          type: string
-          format: date-time
-          description: ISO 8601 timestamp when the local user record was last updated.
 
     ClientSettings:
       type: object
@@ -1295,10 +1287,9 @@ components:
       required: [ clientId, settings ]
       properties:
         clientId:
-          type: string
           description: The client this settings row belongs to (matches the path parameter).
-          pattern: "^[a-z0-9-]{1,32}$"
-          example: web
+          allOf:
+            - $ref: "#/components/schemas/ClientId"
         settings:
           type: object
           description: Free-form JSON object owned by the client. The server stores and returns it as-is and does not validate its shape.
@@ -1306,17 +1297,10 @@ components:
           example:
             theme: dark
             fontSize: 14
-        createdAt:
-          type: string
-          format: date-time
-          description: ISO 8601 timestamp when this client settings row was first created.
-        updatedAt:
-          type: string
-          format: date-time
-          description: ISO 8601 timestamp when this client settings row was last updated.
 
     ClientSettingsWrite:
       type: object
+      additionalProperties: false
       description: Body for upserting per-client settings (PUT semantics — fully replaces any existing settings for the client).
       required: [ settings ]
       properties:

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -10,9 +10,9 @@ info:
 
 servers:
   - url: https://budgetbuddy.glebremniov.keenetic.link
-    description: Production (self-hosted on Raspberry Pi behind nginx).
+    description: Production.
   - url: http://localhost:8080
-    description: Local development (`./gradlew bootRun --args='--spring.profiles.active=dev'`).
+    description: Local development.
 
 tags:
   - name: categories
@@ -134,7 +134,7 @@ paths:
     put:
       tags: [ categories ]
       summary: Replace category
-      description: Fully replaces a category's data (PUT semantics).
+      description: Fully replaces a category's data.
       operationId: replaceCategory
       requestBody:
         required: true
@@ -408,7 +408,7 @@ paths:
     put:
       tags: [ transactions ]
       summary: Replace transaction
-      description: Fully replaces a transaction's data (PUT semantics).
+      description: Fully replaces a transaction's data.
       operationId: replaceTransaction
       requestBody:
         required: true
@@ -842,7 +842,7 @@ components:
           type: [ integer, "null" ]
           format: int64
           minimum: 0
-          description: Monthly spending budget for this category, in minor units. Pass null for no budget.
+          description: Monthly spending budget for this category, in minor units. Pass null to clear the budget.
           example: 50000
 
     CategoryUpdate:
@@ -861,7 +861,7 @@ components:
           type: [ integer, "null" ]
           format: int64
           minimum: 0
-          description: New monthly budget in minor units. Pass null to clear an existing budget.
+          description: New monthly budget in minor units. Pass null to clear the budget.
           example: 75000
 
     Uuid:
@@ -965,7 +965,7 @@ components:
           description: Date on which the transaction occurred (YYYY-MM-DD).
         description:
           type: [ string, "null" ]
-          description: Free-text note for the transaction (1–255 characters). Pass null for no note.
+          description: Free-text note for the transaction (1–255 characters). Pass null to clear the note.
           minLength: 1
           maxLength: 255
 
@@ -998,7 +998,7 @@ components:
           description: New transaction date (YYYY-MM-DD).
         description:
           type: [ string, "null" ]
-          description: Updated free-text note (1–255 characters). Pass null to clear the existing note.
+          description: Updated free-text note (1–255 characters). Pass null to clear the note.
           minLength: 1
           maxLength: 255
 
@@ -1169,12 +1169,13 @@ components:
           description: URI reference identifying the specific occurrence of the problem.
         errors:
           type: array
-          description: Optional list of specific errors (e.g., field-level validation errors).
+          description: Field-level validation errors. Present on 400 responses caused by per-field validation; omitted otherwise.
           items:
             $ref: "#/components/schemas/FieldError"
 
     FieldError:
       type: object
+      additionalProperties: false
       required: [ field, message ]
       properties:
         field:
@@ -1227,7 +1228,7 @@ components:
     UserPreferencesWrite:
       type: object
       additionalProperties: false
-      description: Full replacement of the user's global preferences (PUT semantics).
+      description: Full replacement of the user's global preferences.
       required: [ language, currency, timezone ]
       properties:
         language:
@@ -1270,7 +1271,7 @@ components:
       required: [ id, preferences ]
       properties:
         id:
-          description: The local Budget Buddy user UUID, derived from the OIDC subject on first login. Stable across sessions and used as the owner of all user-scoped resources.
+          description: Stable identifier for the authenticated user. Used as the owner of all user-scoped resources and unchanged across sessions.
           allOf:
             - $ref: "#/components/schemas/Uuid"
         preferences:
@@ -1278,12 +1279,21 @@ components:
           allOf:
             - $ref: "#/components/schemas/UserPreferences"
 
+    ClientSettingsPayload:
+      type: object
+      description: |
+        Free-form JSON object owned by the client app. The server stores and returns it as-is and
+        does not validate its shape — clients own the schema.
+      additionalProperties: true
+      example:
+        theme: dark
+        fontSize: 14
+
     ClientSettings:
       type: object
       description: |
         Per-client UI/UX settings (themes, font sizes, layout preferences, etc.) for a single client
-        of the authenticated user. The `settings` payload is opaque to the server — clients own its
-        schema.
+        of the authenticated user.
       required: [ clientId, settings ]
       properties:
         clientId:
@@ -1291,23 +1301,17 @@ components:
           allOf:
             - $ref: "#/components/schemas/ClientId"
         settings:
-          type: object
-          description: Free-form JSON object owned by the client. The server stores and returns it as-is and does not validate its shape.
-          additionalProperties: true
-          example:
-            theme: dark
-            fontSize: 14
+          description: The stored settings payload.
+          allOf:
+            - $ref: "#/components/schemas/ClientSettingsPayload"
 
     ClientSettingsWrite:
       type: object
       additionalProperties: false
-      description: Body for upserting per-client settings (PUT semantics — fully replaces any existing settings for the client).
+      description: Upsert body — fully replaces any existing settings for the client.
       required: [ settings ]
       properties:
         settings:
-          type: object
-          description: Free-form JSON object owned by the client. Stored and returned as-is.
-          additionalProperties: true
-          example:
-            theme: dark
-            fontSize: 14
+          description: The settings payload to store.
+          allOf:
+            - $ref: "#/components/schemas/ClientSettingsPayload"


### PR DESCRIPTION
## Why

`/v1/users/me` shipped in #103. While reviewing that work, the existing schemas had accumulated inconsistencies — repeated primitives, ambiguous PUT semantics, fields nothing reads, leaky implementation hints — worth resolving as one breaking release. While in the area, also tidied up tooling (pnpm pin, README accuracy, CI consistency).

## What changed

**Schema-design pass** ([`751ca66`](https://github.com/budget-buddy-org/budget-buddy-contracts/commit/751ca66))
- Extracted primitives: `Uuid`, `Month`, `Currency`, `ClientId` schemas + `monthQuery` / `currencyQuery` reusable parameters. `format: uuid` was inlined 8 times, the YYYY-MM regex 5 times — all single-sourced now.
- `additionalProperties: false` on every Write/Update body — typos like `naem` now 400 instead of silently dropping.
- `CategoryWrite.monthlyBudget` and `Transaction(Write).description` moved to `required` + nullable. Removes PUT ambiguity: callers must explicitly send `null` to clear.
- `Transaction.description` is now nullable + `minLength: 1` across Read/Write/Update (was inconsistent — read schema didn't match what the server returns).
- Read schemas now declare invariants the server guarantees: `Transaction.amount` min 1, `Category.name` and `CategorySpendingRow.categoryName` bounded 1..255.
- Dropped `createdAt`/`updatedAt` from `Category`, `Transaction`, `UserPreferences`, `Me`, `ClientSettings` — unused by clients; `Transaction` already has its own `date`.
- `servers`: replaced templated `{scheme}://{host}` with real prod URL + localhost.
- Documented `Problem.errors` in `BadRequest` response so clients know when to expect field-level errors.

**Second polish pass** ([`29a42f1`](https://github.com/budget-buddy-org/budget-buddy-contracts/commit/29a42f1))
- DRY: extracted `ClientSettingsPayload`; `ClientSettings.settings` and `ClientSettingsWrite.settings` now $ref it instead of duplicating the opaque-object shape.
- `additionalProperties: false` on `FieldError` for parity with the strict request schemas.
- Trimmed deployment-specific detail from server descriptions (no more Pi/nginx/gradle) — the spec stays agnostic to how the API is hosted.
- `Me.id` no longer leaks the "derived from OIDC subject on first login" implementation hint — describes the value, not the derivation.
- Dropped `(PUT semantics)` parentheticals and standardized null-clearing wording across Category/Transaction write+update schemas.
- Rewrote `Problem.errors` description to specify *when* it's populated rather than restating "optional".

**Tooling** ([`245f460`](https://github.com/budget-buddy-org/budget-buddy-contracts/commit/245f460), [`dee91ba`](https://github.com/budget-buddy-org/budget-buddy-contracts/commit/dee91ba))
- Pinned `pnpm@11.4.0` via Corepack's `packageManager` field so local and CI converge on one version.
- Bumped `@hey-api/openapi-ts` 0.97.2 → 0.97.3.
- Removed the now-conflicting `version: 10` input from all four workflows so `pnpm/action-setup` reads the version from `packageManager`.

**Docs** ([`0b24db5`](https://github.com/budget-buddy-org/budget-buddy-contracts/commit/0b24db5))
- Fixed factual errors in README: client is fetch (not Axios), pagination is `page`/`size`/`total` (not `total`/`limit`/`offset`), every endpoint requires Bearer JWT (there is no login/register exception).
- Dropped hardcoded `1.1.0` install snippets; trimmed obsolete CLI prerequisites; rewrote release-workflow steps to match the PR + squash-merge flow documented in CLAUDE.md.

## How to verify

- [ ] `pnpm install && pnpm run lint && pnpm run validate` — both pass clean
- [ ] `pnpm run generate` — TS, Java, and Swift all generate without warnings; spot-check that `Category` and `Transaction` types no longer expose `createdAt`/`updatedAt`, and that `ClientSettingsPayload` shows up as a shared type
- [ ] Spot-check that no schema still inlines the primitive patterns — only the primitive definitions should match: `grep -nE 'format: uuid|pattern: "\^\\\\d\{4\}|pattern: "\^\[a-z0-9-\]|pattern: "\^\[A-Z\]\{3\}' specs/openapi.yaml`
- [ ] CI passes — particularly that the pnpm/packageManager conflict is gone after `dee91ba`

## Notes

**Breaking change.** Dropped fields, tightened bodies (`additionalProperties: false`, new required fields), and `Transaction.description` nullability change all require downstream code updates in `budget-buddy-api` and `budget-buddy-web-app`. semantic-release will MAJOR-bump on merge per the `refactor!:` title.