### PR TITLE
feat: publish interactive Swagger UI to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,44 @@
+name: Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "specs/**"
+      - "docs/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Assemble site
+        run: |
+          mkdir -p _site
+          cp docs/index.html _site/
+          cp specs/openapi.yaml _site/
+
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
+
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
+        with:
+          path: _site
+
+      - id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 [![GitHub Release](https://img.shields.io/github/v/release/budget-buddy-org/budget-buddy-contracts)](https://github.com/budget-buddy-org/budget-buddy-contracts/releases)
 [![npm](https://img.shields.io/badge/npm-GPR-blue.svg?logo=npm)](https://github.com/budget-buddy-org/budget-buddy-contracts/pkgs/npm/budget-buddy-contracts)
 [![Maven](https://img.shields.io/badge/maven-GPR-blue.svg?logo=apachemaven)](https://github.com/budget-buddy-org/budget-buddy-contracts/packages/2953418)
+[![API Docs](https://img.shields.io/badge/docs-Swagger%20UI-85ea2d.svg?logo=swagger)](https://budget-buddy-org.github.io/budget-buddy-contracts/)
+
+📖 **Interactive API reference:** <https://budget-buddy-org.github.io/budget-buddy-contracts/>
 
 This repository serves as the **Single Source of Truth** for the Budget Buddy ecosystem. We use a "Contract-First" approach, where the API is defined in OpenAPI 3.1 and then used to generate strongly-typed clients and server interfaces for all supported platforms.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Budget Buddy API — interactive OpenAPI 3.1 reference." />
+    <meta name="color-scheme" content="light dark" />
+    <title>Budget Buddy API</title>
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ccircle cx='8' cy='8' r='7' fill='%2349cc90'/%3E%3C/svg%3E"
+    />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/swagger-ui-dist@5.32.6/swagger-ui.css"
+      crossorigin
+    />
+    <style>
+      body {
+        margin: 0;
+        background: #fafafa;
+      }
+      .swagger-ui .topbar {
+        display: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script
+      src="https://unpkg.com/swagger-ui-dist@5.32.6/swagger-ui-bundle.js"
+      crossorigin
+    ></script>
+    <script>
+      window.addEventListener("load", () => {
+        window.ui = SwaggerUIBundle({
+          url: "./openapi.yaml",
+          dom_id: "#swagger-ui",
+          deepLinking: true,
+          displayRequestDuration: true,
+          persistAuthorization: true,
+          tryItOutEnabled: true,
+          docExpansion: "list",
+          defaultModelsExpandDepth: 0,
+          syntaxHighlight: { theme: "agate" },
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,1 @@
+../specs/openapi.yaml


### PR DESCRIPTION
## Why

The OpenAPI spec in `specs/openapi.yaml` is the single source of truth for the Budget Buddy ecosystem, but until now there was no human-friendly way to browse it — consumers had to read raw YAML or import the spec into their own tools. Hosting Swagger UI on GitHub Pages gives every consumer (web, API, iOS) one canonical URL for the live contract: <https://budget-buddy-org.github.io/budget-buddy-contracts/>.

## What changed

- **`docs/index.html`** — minimal Swagger UI page. `swagger-ui-dist@5.32.6` pinned via unpkg (latest as of writing). Topbar hidden (single fixed spec), `deepLinking`, `persistAuthorization`, `displayRequestDuration`, `docExpansion: "list"`, inline SVG favicon. No build step, no JS deps added to `package.json`.
- **`docs/openapi.yaml`** — relative symlink to `../specs/openapi.yaml` so the page works in local preview (`python3 -m http.server --directory docs`) without duplicating the spec. The workflow copies the real file at deploy time, so the symlink is dev-only.
- **`.github/workflows/pages.yml`** — deploys on push to `main` (paths-filtered to `specs/`, `docs/`, and the workflow itself) plus `workflow_dispatch`. Assembles `_site/` from `docs/index.html` + a fresh copy of `specs/openapi.yaml` so the deployed spec cannot drift from source. SHA-pinned official Pages actions (`configure-pages` v6, `upload-pages-artifact` v5, `deploy-pages` v5), matching the repo's existing pinning convention. Concurrency group prevents overlapping deploys; `pages: write` + `id-token: write` scoped to this workflow only.
- **`README.md`** — Swagger UI badge and a direct link to the hosted reference near the top.

## How to verify

1. Repo → Settings → Pages → set **Source: GitHub Actions** (one-time, before merging).
2. After merge to `main`, watch the `Pages` workflow in Actions — it should run and succeed.
3. Open <https://budget-buddy-org.github.io/budget-buddy-contracts/> — the spec should render with `info.version` matching the latest release tag.
4. Confirm tag/operation deep links work (click a tag, copy URL, reopen — should land on the same operation).
5. Local preview: `python3 -m http.server --directory docs 8080` → <http://localhost:8080> renders the same UI off the symlinked spec.

## Notes

- No version bump: per the CLAUDE.md bump policy, CI/tooling additions that don't affect any generated client output skip the bump.
- Triggering on push-to-`main` (not `release: published`) means docs update as soon as `semantic-release` lands the version-bumped spec on `main`, so there's no lag between a release and the published docs.
- `unpkg` is pinned to an exact version for determinism; bump intentionally when a UI refresh is desired.