### PR TITLE
ci: deploy Pages on release published, not on push to main

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,13 +1,8 @@
 name: Pages
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "specs/**"
-      - "docs/**"
-      - ".github/workflows/pages.yml"
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Why

The Pages workflow currently fires on every push to `main`, but the publish pipeline (`publish.yml`) is keyed on `release: published`. Aligning Pages with the same signal means the hosted docs ship in lockstep with each published GitHub Release — the spec rendered at <https://budget-buddy-org.github.io/budget-buddy-contracts/> will always match the latest released version, not whatever's transiently sitting on `main` mid-release.

## What changed

- `.github/workflows/pages.yml`: replace the `push: branches: main` trigger with `release: { types: [published] }`. `workflow_dispatch` is retained for manual re-deploys.

## How to verify

1. Merge this PR — the Pages workflow should **not** run on the merge commit.
2. On the next semantic-release run (any `feat:`/`fix:` PR that lands on `main`), the release flow publishes a GitHub Release → Pages workflow runs from the `release: published` event → docs at <https://budget-buddy-org.github.io/budget-buddy-contracts/> reflect the new `info.version`.
3. Manual sanity check: Actions → Pages → Run workflow → deploy succeeds.

## Notes

- Mirrors the existing `publish.yml` pattern, so the mental model "release published → all downstream artifacts ship" stays consistent (npm + Maven + Pages).
- Trade-off: docs no longer update for tooling-only PRs that touch `docs/` without cutting a release. For those, use `workflow_dispatch`.