### PR TITLE
feat: rename PUT operationIds from replaceX to updateX

### DIFF
--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -155,9 +155,9 @@ paths:
 
     put:
       tags: [ categories ]
-      summary: Replace category
-      description: Fully replaces a category's data.
-      operationId: replaceCategory
+      summary: Update category
+      description: Fully updates a category's data.
+      operationId: updateCategory
       requestBody:
         required: true
         content:
@@ -166,7 +166,7 @@ paths:
               $ref: "#/components/schemas/CategoryWrite"
       responses:
         "200":
-          description: Replaced category
+          description: Updated category
           content:
             application/json:
               schema:
@@ -402,9 +402,9 @@ paths:
 
     put:
       tags: [ transactions ]
-      summary: Replace transaction
-      description: Fully replaces a transaction's data.
-      operationId: replaceTransaction
+      summary: Update transaction
+      description: Fully updates a transaction's data.
+      operationId: updateTransaction
       requestBody:
         required: true
         content:
@@ -413,7 +413,7 @@ paths:
               $ref: "#/components/schemas/TransactionWrite"
       responses:
         "200":
-          description: Replaced transaction
+          description: Updated transaction
           content:
             application/json:
               schema:
@@ -528,11 +528,11 @@ paths:
 
     put:
       tags: [ users ]
-      summary: Replace current user's preferences
+      summary: Update current user's preferences
       description: |
-        Fully replaces the authenticated user's global preferences. All fields in the body are
+        Fully updates the authenticated user's global preferences. All fields in the body are
         applied; the preferences row is created on first call.
-      operationId: replaceCurrentUserPreferences
+      operationId: updateCurrentUserPreferences
       requestBody:
         required: true
         content:
@@ -541,7 +541,7 @@ paths:
               $ref: "#/components/schemas/UserPreferencesWrite"
       responses:
         "200":
-          description: Replaced preferences
+          description: Updated preferences
           content:
             application/json:
               schema:
@@ -1120,7 +1120,7 @@ components:
     UserPreferencesWrite:
       type: object
       additionalProperties: false
-      description: Full replacement of the user's global preferences.
+      description: Full update of the user's global preferences.
       required: [ language, currency, timezone ]
       properties:
         language:


### PR DESCRIPTION
## Why

The PUT mutation operations were named `replaceCategory`, `replaceTransaction`, and `replaceCurrentUserPreferences`. The API implementation's CRUDL layer uses "update" terminology throughout, so the generated SDK method names drifted from the server-side vocabulary. This aligns the contract with that terminology.

## What changed

- **operationIds renamed** (drives generated SDK method names):
  - `replaceCategory` → `updateCategory`
  - `replaceTransaction` → `updateTransaction`
  - `replaceCurrentUserPreferences` → `updateCurrentUserPreferences`
- Matching `summary`, `description`, and `200` response descriptions reworded from "replace" to "update".
- `UserPreferencesWrite` schema description: "Full replacement of…" → "Full update of the user's global preferences."

## How to verify

1. `pnpm run lint` → no errors.
2. `pnpm run validate` → no validation issues.
3. `pnpm run generate:java` then confirm the generated interfaces expose `updateCategory` / `updateTransaction` / `updateCurrentUserPreferences` and contain zero `replaceX` methods (`grep -rl "replaceCategory\|replaceTransaction\|replaceCurrentUserPreferences" generated/java` returns nothing).

## Notes

- The HTTP contract (paths, verbs, request/response shapes) is unchanged — only generated method names differ. Versioned as a **minor** (`feat:` → `6.1.0`) on that basis.
- `upsertCurrentUserClientSettings` is intentionally left unchanged; its create-or-overwrite semantics are distinct from a plain update.
- **Follow-up (blocked on 6.1.0 publish):** `budget-buddy-api` must bump to `6.1.0` and rename its three controller `@Override`s (`replaceCategory`→`updateCategory`, etc.) to match the renamed interface methods.