### PR TITLE
fix(swift): unwrap regex literal delimiters in generated patterns

### DIFF
--- a/Sources/BudgetBuddyContracts/Models/CategorySpendingSummary.swift
+++ b/Sources/BudgetBuddyContracts/Models/CategorySpendingSummary.swift
@@ -9,8 +9,8 @@ import Foundation
 
 public struct CategorySpendingSummary: Sendable, Codable, Hashable {
 
-    public static let monthRule = StringRule(minLength: nil, maxLength: nil, pattern: "/^\\d{4}-(0[1-9]|1[0-2])$/")
-    public static let currencyRule = StringRule(minLength: nil, maxLength: nil, pattern: "/^[A-Z]{3}$/")
+    public static let monthRule = StringRule(minLength: nil, maxLength: nil, pattern: "^\\d{4}-(0[1-9]|1[0-2])$")
+    public static let currencyRule = StringRule(minLength: nil, maxLength: nil, pattern: "^[A-Z]{3}$")
     /** Calendar month echoed back from the request. */
     public var month: String
     /** ISO 4217 currency code echoed back from the request. */

--- a/Sources/BudgetBuddyContracts/Models/ClientSettings.swift
+++ b/Sources/BudgetBuddyContracts/Models/ClientSettings.swift
@@ -10,7 +10,7 @@ import Foundation
 /** Per-client UI/UX settings (themes, font sizes, layout preferences, etc.) for a single client of the authenticated user.  */
 public struct ClientSettings: Sendable, Codable, Hashable {
 
-    public static let clientIdRule = StringRule(minLength: nil, maxLength: nil, pattern: "/^[a-z0-9-]{1,32}$/")
+    public static let clientIdRule = StringRule(minLength: nil, maxLength: nil, pattern: "^[a-z0-9-]{1,32}$")
     /** The client this settings row belongs to (matches the path parameter). */
     public var clientId: String
     /** The stored settings payload. */

--- a/Sources/BudgetBuddyContracts/Models/MonthlySummary.swift
+++ b/Sources/BudgetBuddyContracts/Models/MonthlySummary.swift
@@ -9,8 +9,8 @@ import Foundation
 
 public struct MonthlySummary: Sendable, Codable, Hashable {
 
-    public static let monthRule = StringRule(minLength: nil, maxLength: nil, pattern: "/^\\d{4}-(0[1-9]|1[0-2])$/")
-    public static let currencyRule = StringRule(minLength: nil, maxLength: nil, pattern: "/^[A-Z]{3}$/")
+    public static let monthRule = StringRule(minLength: nil, maxLength: nil, pattern: "^\\d{4}-(0[1-9]|1[0-2])$")
+    public static let currencyRule = StringRule(minLength: nil, maxLength: nil, pattern: "^[A-Z]{3}$")
     public static let incomeRule = NumericRule<Int64>(minimum: 0, exclusiveMinimum: false, maximum: nil, exclusiveMaximum: false, multipleOf: nil)
     public static let expenseRule = NumericRule<Int64>(minimum: 0, exclusiveMinimum: false, maximum: nil, exclusiveMaximum: false, multipleOf: nil)
     public static let incomeCountRule = NumericRule<Int>(minimum: 0, exclusiveMinimum: false, maximum: nil, exclusiveMaximum: false, multipleOf: nil)

--- a/Sources/BudgetBuddyContracts/Models/Transaction.swift
+++ b/Sources/BudgetBuddyContracts/Models/Transaction.swift
@@ -10,7 +10,7 @@ import Foundation
 public struct Transaction: Sendable, Codable, Hashable {
 
     public static let amountRule = NumericRule<Int64>(minimum: 1, exclusiveMinimum: false, maximum: nil, exclusiveMaximum: false, multipleOf: nil)
-    public static let currencyRule = StringRule(minLength: nil, maxLength: nil, pattern: "/^[A-Z]{3}$/")
+    public static let currencyRule = StringRule(minLength: nil, maxLength: nil, pattern: "^[A-Z]{3}$")
     public static let descriptionRule = StringRule(minLength: 1, maxLength: 255, pattern: nil)
     /** Unique identifier for the transaction. */
     public var id: UUID

--- a/Sources/BudgetBuddyContracts/Models/TransactionWrite.swift
+++ b/Sources/BudgetBuddyContracts/Models/TransactionWrite.swift
@@ -10,7 +10,7 @@ import Foundation
 public struct TransactionWrite: Sendable, Codable, Hashable {
 
     public static let amountRule = NumericRule<Int64>(minimum: 1, exclusiveMinimum: false, maximum: nil, exclusiveMaximum: false, multipleOf: nil)
-    public static let currencyRule = StringRule(minLength: nil, maxLength: nil, pattern: "/^[A-Z]{3}$/")
+    public static let currencyRule = StringRule(minLength: nil, maxLength: nil, pattern: "^[A-Z]{3}$")
     public static let descriptionRule = StringRule(minLength: 1, maxLength: 255, pattern: nil)
     /** UUID of the category this transaction belongs to. */
     public var categoryId: UUID

--- a/Sources/BudgetBuddyContracts/Models/UserPreferences.swift
+++ b/Sources/BudgetBuddyContracts/Models/UserPreferences.swift
@@ -10,8 +10,8 @@ import Foundation
 /** Global, cross-client preferences for the authenticated user. Used by server-side logic (formatting, future notifications) and by clients that want a consistent locale across sessions.  */
 public struct UserPreferences: Sendable, Codable, Hashable {
 
-    public static let languageRule = StringRule(minLength: 2, maxLength: 7, pattern: "/^[a-z]{2,3}(-[A-Z]{2})?$/")
-    public static let currencyRule = StringRule(minLength: nil, maxLength: nil, pattern: "/^[A-Z]{3}$/")
+    public static let languageRule = StringRule(minLength: 2, maxLength: 7, pattern: "^[a-z]{2,3}(-[A-Z]{2})?$")
+    public static let currencyRule = StringRule(minLength: nil, maxLength: nil, pattern: "^[A-Z]{3}$")
     public static let timezoneRule = StringRule(minLength: 1, maxLength: 64, pattern: nil)
     /** Preferred language as a BCP 47 tag. */
     public var language: String

--- a/Sources/BudgetBuddyContracts/Models/UserPreferencesWrite.swift
+++ b/Sources/BudgetBuddyContracts/Models/UserPreferencesWrite.swift
@@ -10,8 +10,8 @@ import Foundation
 /** Full update of the user&#39;s global preferences. */
 public struct UserPreferencesWrite: Sendable, Codable, Hashable {
 
-    public static let languageRule = StringRule(minLength: 2, maxLength: 7, pattern: "/^[a-z]{2,3}(-[A-Z]{2})?$/")
-    public static let currencyRule = StringRule(minLength: nil, maxLength: nil, pattern: "/^[A-Z]{3}$/")
+    public static let languageRule = StringRule(minLength: 2, maxLength: 7, pattern: "^[a-z]{2,3}(-[A-Z]{2})?$")
+    public static let currencyRule = StringRule(minLength: nil, maxLength: nil, pattern: "^[A-Z]{3}$")
     public static let timezoneRule = StringRule(minLength: 1, maxLength: 64, pattern: nil)
     /** Preferred language as a BCP 47 tag. */
     public var language: String

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "spectral lint specs/openapi.yaml --ruleset .spectral.yaml",
     "generate:ts": "openapi-ts",
     "generate:java": "openapi-generator-cli generate -i specs/openapi.yaml -g spring -o generated/java -c config/spring-server.yaml --additional-properties=artifactVersion=$(node -p \"require('./package.json').version\")",
-    "generate:swift": "openapi-generator-cli generate -i specs/openapi.yaml -g swift6 -o /tmp/budget-buddy-swift -c config/swift6.yaml && rsync -a --delete /tmp/budget-buddy-swift/Sources/BudgetBuddyContracts/ Sources/BudgetBuddyContracts/",
+    "generate:swift": "openapi-generator-cli generate -i specs/openapi.yaml -g swift6 -o /tmp/budget-buddy-swift -c config/swift6.yaml && rsync -a --delete /tmp/budget-buddy-swift/Sources/BudgetBuddyContracts/ Sources/BudgetBuddyContracts/ && node scripts/normalize-swift-patterns.mjs",
     "generate": "pnpm run generate:ts && pnpm run generate:java && pnpm run generate:swift",
     "release": "semantic-release",
     "release:dry-run": "semantic-release --dry-run"

--- a/scripts/normalize-swift-patterns.mjs
+++ b/scripts/normalize-swift-patterns.mjs
@@ -10,25 +10,25 @@
 // This strips the leading/trailing `/` from generated pattern literals so the
 // emitted regex is usable by NSRegularExpression. It is idempotent and is run
 // automatically as the last step of `pnpm run generate:swift`.
+//
+// After normalizing, it re-scans the sources and exits non-zero if any wrapped
+// `pattern: "/…/"` literal survives. CI does not smoke-test Swift generation,
+// so this self-check is the guard that catches a future generator bump that
+// changes the wrapping style — failing loudly instead of silently shipping
+// regex rules that can never match.
 
-import { readdirSync, readFileSync, writeFileSync, statSync } from "node:fs";
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-const ROOT = "Sources/BudgetBuddyContracts";
+// Anchor to the repo root relative to this script, not the caller's cwd.
+const ROOT = join(import.meta.dirname, "..", "Sources/BudgetBuddyContracts");
 // Matches `pattern: "/<regex>/"` and captures the bare <regex>.
 const WRAPPED_PATTERN = /pattern: "\/(.*)\/"/g;
 
 function swiftFiles(dir) {
-  const files = [];
-  for (const entry of readdirSync(dir)) {
-    const full = join(dir, entry);
-    if (statSync(full).isDirectory()) {
-      files.push(...swiftFiles(full));
-    } else if (entry.endsWith(".swift")) {
-      files.push(full);
-    }
-  }
-  return files;
+  return readdirSync(dir, { recursive: true, withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".swift"))
+    .map((entry) => join(entry.parentPath, entry.name));
 }
 
 let changedFiles = 0;
@@ -51,3 +51,22 @@ for (const file of swiftFiles(ROOT)) {
 console.log(
   `normalize-swift-patterns: unwrapped ${changedRules} regex pattern(s) across ${changedFiles} file(s)`
 );
+
+// Guard against the bug *class*, not just the exact shape handled above: any
+// `pattern: "…"` whose value still opens with a delimiter slash is broken for
+// NSRegularExpression. This deliberately differs from WRAPPED_PATTERN so it can
+// catch a future generator change (e.g. trailing regex flags like `/…/i`) that
+// WRAPPED_PATTERN would silently fail to unwrap. CI does not smoke-test Swift
+// generation, so fail loudly here rather than ship rules that can never match.
+const LEADING_DELIMITER = /pattern: "\//;
+const survivors = swiftFiles(ROOT).filter((file) =>
+  LEADING_DELIMITER.test(readFileSync(file, "utf8"))
+);
+if (survivors.length > 0) {
+  console.error(
+    `normalize-swift-patterns: pattern literals still wrapped in regex ` +
+      `delimiters after normalization in:\n  ${survivors.join("\n  ")}\n` +
+      `The generator's pattern format may have changed — update WRAPPED_PATTERN.`
+  );
+  process.exit(1);
+}

--- a/scripts/normalize-swift-patterns.mjs
+++ b/scripts/normalize-swift-patterns.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+// Post-processing for the generated Swift sources.
+//
+// openapi-generator (swift6) emits string `pattern` rules wrapped in JS-style
+// regex-literal delimiters, e.g. `StringRule(pattern: "/^[A-Z]{3}$/")`. The
+// generated `Validator` feeds that pattern straight to `NSRegularExpression`,
+// which treats the surrounding slashes as literal characters — so pattern
+// validation (currency, month, slug, locale, …) never matches.
+//
+// This strips the leading/trailing `/` from generated pattern literals so the
+// emitted regex is usable by NSRegularExpression. It is idempotent and is run
+// automatically as the last step of `pnpm run generate:swift`.
+
+import { readdirSync, readFileSync, writeFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = "Sources/BudgetBuddyContracts";
+// Matches `pattern: "/<regex>/"` and captures the bare <regex>.
+const WRAPPED_PATTERN = /pattern: "\/(.*)\/"/g;
+
+function swiftFiles(dir) {
+  const files = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      files.push(...swiftFiles(full));
+    } else if (entry.endsWith(".swift")) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+let changedFiles = 0;
+let changedRules = 0;
+
+for (const file of swiftFiles(ROOT)) {
+  const original = readFileSync(file, "utf8");
+  let count = 0;
+  const updated = original.replace(WRAPPED_PATTERN, (_match, inner) => {
+    count += 1;
+    return `pattern: "${inner}"`;
+  });
+  if (count > 0) {
+    writeFileSync(file, updated);
+    changedFiles += 1;
+    changedRules += count;
+  }
+}
+
+console.log(
+  `normalize-swift-patterns: unwrapped ${changedRules} regex pattern(s) across ${changedFiles} file(s)`
+);


### PR DESCRIPTION
## Problem

`openapi-generator` (swift6) emits string `pattern` rules wrapped in JS-style regex-literal delimiters:

```swift
public static let currencyRule = StringRule(minLength: nil, maxLength: nil, pattern: "/^[A-Z]{3}$/")
```

The generated `Validator.validate(_:against:)` passes that pattern **directly** to `NSRegularExpression`, which has no concept of `/…/` literals and treats the slashes as literal characters. As a result the regex can never match, so **every pattern-based validation silently fails** — `currency` (`^[A-Z]{3}$`), `month` (`^\d{4}-(0[1-9]|1[0-2])$`), client-id `slug`, and `language`/locale.

The OpenAPI spec itself is correct (`specs/openapi.yaml` declares `pattern: "^[A-Z]{3}$"` with no slashes) — the delimiters are added by the generator's Swift templates, so this affects any Swift consumer that uses the generated `Validator`.

## Fix

There are no custom mustache templates and the generator exposes no option to disable the wrapping, so this adds a small post-generation normalization step:

- **`scripts/normalize-swift-patterns.mjs`** — strips the `/…/` delimiters from `pattern: "…"` literals in the generated Swift sources. Idempotent; pure Node (no new deps).
- **`generate:swift`** now runs it as its final step, so the corrected output is reproduced on every regeneration (including the release-time `prepare` step in `.releaserc.cjs`).
- Applied the same normalization to the **currently committed `Sources/`** (11 patterns across 7 files), since CI doesn't smoke-test Swift generation and SPM consumes the committed sources directly.

## Verification

- `node scripts/normalize-swift-patterns.mjs` → `unwrapped 11 regex pattern(s) across 7 file(s)`; no `pattern: "/` literals remain.
- `swift build` → **Build complete.**
- The change is confined to string-literal content, so it's compile-safe; a release-time regen reproduces identical output (generator pinned at 7.21.0, spec unchanged).

Found while wiring schema-driven input validation in the iOS app (it currently strips the delimiters client-side as a workaround; this lets that workaround be removed once a release ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)