### PR TITLE
chore: ignore SwiftPM .build/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ generated/
 .openapi-generator/
 .openapi-generator-ignore
 
+# Swift Package Manager build artifacts (created by `swift build` when verifying
+# the generated Sources locally — never committed).
+.build/
+
 ### macOS ###
 # General
 .DS_Store


### PR DESCRIPTION
## What

Add `.build/` to `.gitignore`.

## Why

`swift build` — which we run to verify the generated `Sources/BudgetBuddyContracts/` compile after `generate:swift` (now including the pattern-normalization step from #120) — produces a local `.build/` directory. It was never gitignored, so it could be accidentally committed. This closes that hygiene gap.

No spec, generator, or source changes. `chore:` → no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)