### PR TITLE
docs(errors): add error type docs and wire type URIs into Problem responses

### DIFF
--- a/docs/errors/bad-request.md
+++ b/docs/errors/bad-request.md
@@ -1,0 +1,35 @@
+# Bad Request
+
+**HTTP status:** `400 Bad Request`
+**`type` URI:** `https://github.com/budget-buddy-org/budget-buddy-contracts/blob/main/docs/errors/bad-request.md`
+
+## What it means
+
+The request is semantically invalid — a logical or cross-field constraint was violated. Unlike a [Validation Error](./validation-error.md), this error cannot be attributed to a single field, so the `errors` array is **not present**. The human-readable explanation is in `detail`.
+
+## Causes
+
+| Endpoint | Trigger |
+|----------|---------|
+| `GET /v1/transactions/summary/trend` | `to` is before `from` |
+| `GET /v1/transactions/summary/trend` | The range between `from` and `to` exceeds 24 months |
+| `GET /v1/transactions` | `amountMax` is less than `amountMin` |
+
+## Response shape
+
+```json
+{
+  "type": "https://github.com/budget-buddy-org/budget-buddy-contracts/blob/main/docs/errors/bad-request.md",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "Range between 'from' and 'to' must not exceed 24 months."
+}
+```
+
+## How to fix
+
+Read `detail` for the specific constraint that was violated and adjust the request accordingly.
+
+## Related errors
+
+- [Validation Error](./validation-error.md) — 400 with `errors[]`; a per-field constraint failed.

--- a/docs/errors/internal-error.md
+++ b/docs/errors/internal-error.md
@@ -1,0 +1,31 @@
+# Internal Server Error
+
+**HTTP status:** `500 Internal Server Error`
+**`type` URI:** `https://github.com/budget-buddy-org/budget-buddy-contracts/blob/main/docs/errors/internal-error.md`
+
+## What it means
+
+An unexpected error occurred on the server. This is not caused by the content of the request. The `errors` array is never present. `detail` contains a generic message safe for display; the root cause is logged server-side.
+
+## Causes
+
+| Cause | Notes |
+|-------|-------|
+| Database connectivity issue | Transient; retry with exponential back-off |
+| Unhandled exception | A code path the server did not anticipate |
+| Identity provider unreachable | Only during `DELETE /v1/users/me` — the IDP call is required before local data is deleted; if it fails, no data is deleted and 500 is returned so the client can retry |
+
+## Response shape
+
+```json
+{
+  "type": "https://github.com/budget-buddy-org/budget-buddy-contracts/blob/main/docs/errors/internal-error.md",
+  "title": "Internal Server Error",
+  "status": 500,
+  "detail": "An unexpected error occurred. Please try again later."
+}
+```
+
+## How to fix
+
+Retry with exponential back-off for transient failures. If the problem persists across retries, the issue is on the server side and not actionable by the client — surface a user-friendly message and optionally report the `instance` value (if present) to support for tracing.

--- a/docs/errors/not-found.md
+++ b/docs/errors/not-found.md
@@ -1,0 +1,36 @@
+# Not Found
+
+**HTTP status:** `404 Not Found`
+**`type` URI:** `https://github.com/budget-buddy-org/budget-buddy-contracts/blob/main/docs/errors/not-found.md`
+
+## What it means
+
+The requested resource does not exist, has been deleted, or belongs to a different user. Resources are strictly scoped to the authenticated user; a resource belonging to another user returns 404 (not 403) to avoid leaking information about resource existence.
+
+## Causes
+
+| Endpoint | Trigger |
+|----------|---------|
+| `GET /v1/categories/{categoryId}` | Category does not exist or is owned by another user |
+| `PUT /v1/categories/{categoryId}` | Same |
+| `DELETE /v1/categories/{categoryId}` | Same |
+| `GET /v1/transactions/{transactionId}` | Transaction does not exist or is owned by another user |
+| `PUT /v1/transactions/{transactionId}` | Same |
+| `DELETE /v1/transactions/{transactionId}` | Same |
+| `GET /v1/users/me/settings/{clientId}` | No settings row has been stored for that client yet |
+| `DELETE /v1/users/me/settings/{clientId}` | Same |
+
+## Response shape
+
+```json
+{
+  "type": "https://github.com/budget-buddy-org/budget-buddy-contracts/blob/main/docs/errors/not-found.md",
+  "title": "Not Found",
+  "status": 404,
+  "detail": "Category 550e8400-e29b-41d4-a716-446655440000 not found."
+}
+```
+
+## How to fix
+
+Verify the ID in the path is correct and that the resource belongs to the currently authenticated user. For client settings, call `PUT /v1/users/me/settings/{clientId}` first to create the settings row before reading or deleting it.

--- a/docs/errors/unauthorized.md
+++ b/docs/errors/unauthorized.md
@@ -1,0 +1,36 @@
+# Unauthorized
+
+**HTTP status:** `401 Unauthorized`
+**`type` URI:** `https://github.com/budget-buddy-org/budget-buddy-contracts/blob/main/docs/errors/unauthorized.md`
+
+## What it means
+
+The request could not be authenticated. Every endpoint in this API requires a valid OIDC-issued JWT access token provided as:
+
+```
+Authorization: Bearer <jwt>
+```
+
+## Causes
+
+| Trigger | Notes |
+|---------|-------|
+| `Authorization` header absent | No credentials were sent |
+| Token malformed or tampered | Signature verification failed |
+| Token issued by an untrusted provider | The identity provider is not configured in the server |
+| Token expired | JWTs have a finite `exp` claim; re-authenticate to get a fresh token |
+
+## Response shape
+
+```json
+{
+  "type": "https://github.com/budget-buddy-org/budget-buddy-contracts/blob/main/docs/errors/unauthorized.md",
+  "title": "Unauthorized",
+  "status": 401,
+  "detail": "Bearer token is missing or invalid."
+}
+```
+
+## How to fix
+
+Re-authenticate with the identity provider (Zitadel OIDC) to obtain a fresh access token, then retry the request with the new token. There are no login endpoints in this API — the auth flow is handled out-of-band.

--- a/docs/errors/validation-error.md
+++ b/docs/errors/validation-error.md
@@ -1,0 +1,43 @@
+# Validation Error
+
+**HTTP status:** `400 Bad Request`
+**`type` URI:** `https://github.com/budget-buddy-org/budget-buddy-contracts/blob/main/docs/errors/validation-error.md`
+
+## What it means
+
+One or more request body or query parameter fields failed structural validation. The `errors` array is **always present** and contains at least one `FieldError` entry identifying the offending field and explaining what is wrong.
+
+## Causes
+
+| Trigger | Example |
+|---------|---------|
+| Required field absent | `name` missing from `CategoryWrite` |
+| String too short or too long | `name: ""` (min 1) or `name` exceeds 255 chars |
+| Number below minimum | `amount: 0` (min 1) or `monthlyBudget: -1` (min 0) |
+| Enum value not in allowed set | `type: "OTHER"` instead of `EXPENSE` / `INCOME` |
+| Invalid format | `categoryId` not a valid UUID; `date` not `YYYY-MM-DD` |
+| Unknown additional property | Any extra key on a `Write` body (`additionalProperties: false`) |
+| Pattern mismatch | `currency: "eur"` (must be `^[A-Z]{3}$`) |
+
+## Response shape
+
+```json
+{
+  "type": "https://github.com/budget-buddy-org/budget-buddy-contracts/blob/main/docs/errors/validation-error.md",
+  "title": "Validation Error",
+  "status": 400,
+  "detail": "Request contains invalid fields.",
+  "errors": [
+    { "field": "amount",   "message": "must be greater than or equal to 1" },
+    { "field": "currency", "message": "must match \"^[A-Z]{3}$\"" }
+  ]
+}
+```
+
+## How to fix
+
+Inspect each entry in `errors[]`. The `field` name matches the JSON key in your request body (or the query parameter name for query inputs). Fix each reported issue and retry the request.
+
+## Related errors
+
+- [Bad Request](./bad-request.md) — 400 without `errors[]`; a semantic or cross-field rule failed.

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -724,6 +724,26 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/Problem"
+          examples:
+            validationError:
+              summary: Per-field validation failure (errors[] present)
+              value:
+                type: "https://github.com/budget-buddy-org/budget-buddy-contracts/blob/main/docs/errors/validation-error.md"
+                title: "Validation Error"
+                status: 400
+                detail: "Request contains invalid fields."
+                errors:
+                  - field: "amount"
+                    message: "must be greater than or equal to 1"
+                  - field: "currency"
+                    message: "must match \"^[A-Z]{3}$\""
+            badRequest:
+              summary: Semantic / cross-field validation failure (no errors[])
+              value:
+                type: "https://github.com/budget-buddy-org/budget-buddy-contracts/blob/main/docs/errors/bad-request.md"
+                title: "Bad Request"
+                status: 400
+                detail: "Range between 'from' and 'to' must not exceed 24 months."
 
     Unauthorized:
       description: Authentication failed
@@ -731,6 +751,14 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/Problem"
+          examples:
+            unauthorized:
+              summary: Missing or invalid bearer token
+              value:
+                type: "https://github.com/budget-buddy-org/budget-buddy-contracts/blob/main/docs/errors/unauthorized.md"
+                title: "Unauthorized"
+                status: 401
+                detail: "Bearer token is missing or invalid."
 
     NotFound:
       description: Resource not found
@@ -738,6 +766,14 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/Problem"
+          examples:
+            notFound:
+              summary: Resource does not exist or belongs to another user
+              value:
+                type: "https://github.com/budget-buddy-org/budget-buddy-contracts/blob/main/docs/errors/not-found.md"
+                title: "Not Found"
+                status: 404
+                detail: "Category 550e8400-e29b-41d4-a716-446655440000 not found."
 
     InternalServerError:
       description: Unexpected server error
@@ -745,6 +781,14 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/Problem"
+          examples:
+            internalError:
+              summary: Unexpected server-side failure
+              value:
+                type: "https://github.com/budget-buddy-org/budget-buddy-contracts/blob/main/docs/errors/internal-error.md"
+                title: "Internal Server Error"
+                status: 500
+                detail: "An unexpected error occurred. Please try again later."
 
   schemas:
     Category:
@@ -1044,7 +1088,19 @@ components:
         type:
           type: string
           format: uri
-          description: URI that identifies the problem type. Defaults to "about:blank" when not set.
+          description: |
+            URI that identifies the problem type. When set by this API it points to a human-readable
+            page documenting the error. Possible values:
+
+            | URI | HTTP status | Description |
+            |-----|-------------|-------------|
+            | `https://github.com/budget-buddy-org/budget-buddy-contracts/blob/main/docs/errors/validation-error.md` | 400 | Per-field validation failure; `errors[]` is populated |
+            | `https://github.com/budget-buddy-org/budget-buddy-contracts/blob/main/docs/errors/bad-request.md` | 400 | Semantic / cross-field violation; no `errors[]` |
+            | `https://github.com/budget-buddy-org/budget-buddy-contracts/blob/main/docs/errors/unauthorized.md` | 401 | Missing, expired, or invalid bearer token |
+            | `https://github.com/budget-buddy-org/budget-buddy-contracts/blob/main/docs/errors/not-found.md` | 404 | Resource does not exist or belongs to another user |
+            | `https://github.com/budget-buddy-org/budget-buddy-contracts/blob/main/docs/errors/internal-error.md` | 500 | Unexpected server-side failure |
+
+            Defaults to `"about:blank"` when not set.
           default: "about:blank"
         title:
           type: string


### PR DESCRIPTION
## Summary

- Created `docs/errors/` with one markdown page per RFC 9457 problem type: `validation-error`, `bad-request`, `unauthorized`, `not-found`, `internal-error`. Each page documents causes, the exact JSON response shape, and how to fix/recover.
- Updated `Problem.type` description with a full lookup table mapping each URI to its HTTP status and meaning.
- Added `examples` to every response component in `specs/openapi.yaml` so Swagger UI and generated clients surface realistic, actionable payloads. `BadRequest` gets two examples — one for per-field validation (with `errors[]`) and one for semantic/cross-field errors (no `errors[]`).

## Error types documented

| Type URI suffix | Status | When |
|-----------------|--------|------|
| `validation-error.md` | 400 | Per-field constraint failed; `errors[]` populated |
| `bad-request.md` | 400 | Semantic / cross-field rule violated (e.g. trend range > 24 months) |
| `unauthorized.md` | 401 | Missing, expired, or untrusted bearer token |
| `not-found.md` | 404 | Resource absent or owned by another user |
| `internal-error.md` | 500 | Unexpected server failure |

## Test plan

- [ ] `pnpm run lint` — no errors
- [ ] `pnpm run validate` — no validation issues
- [ ] Review each `docs/errors/*.md` page renders correctly on GitHub
- [ ] Check Swagger UI shows the new examples in the response panels

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMRt4bgmjxSE7UT2MypBo6)_