### PR TITLE
fix(sonar): SRI, globalThis, job-level permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,13 +12,14 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   publish-typescript:
     name: Publish TypeScript
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      packages: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
@@ -59,6 +60,8 @@ jobs:
     name: Publish Java
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      packages: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,7 +14,8 @@
     <link
       rel="stylesheet"
       href="https://unpkg.com/swagger-ui-dist@5.32.6/swagger-ui.css"
-      crossorigin
+      integrity="sha384-9Q2fpS+xeS4ffJy6CagnwoUl+4ldAYhOs9pgZuEKxypVModhmZFzeMlvVsAjf7uT"
+      crossorigin="anonymous"
     />
     <style>
       body {
@@ -30,11 +31,12 @@
     <div id="swagger-ui"></div>
     <script
       src="https://unpkg.com/swagger-ui-dist@5.32.6/swagger-ui-bundle.js"
-      crossorigin
+      integrity="sha384-EYdOaiRwn44zNjrw+Tfs06qYz9BGQVo2f4/pLY5i7VorbjnZNhdplAbTBk8FXHUJ"
+      crossorigin="anonymous"
     ></script>
     <script>
-      window.addEventListener("load", () => {
-        window.ui = SwaggerUIBundle({
+      globalThis.addEventListener("load", () => {
+        globalThis.ui = SwaggerUIBundle({
           url: "./openapi.yaml",
           dom_id: "#swagger-ui",
           deepLinking: true,


### PR DESCRIPTION
## Why

SonarQube flagged 4 open issues (1 MAJOR, 3 MINOR) across the docs page and the publish workflow. This PR resolves all of them to keep the quality gate clean.

## What changed

- **SRI on CDN assets** (`docs/index.html`, S5725 ×2) — Added `integrity="sha384-..."` and `crossorigin="anonymous"` to both the Swagger UI CSS `<link>` and JS `<script>` tags. Without SRI, a compromised unpkg CDN could serve malicious assets; hashes were computed from the pinned `5.32.6` release.

- **`globalThis` over `window`** (`docs/index.html`, S7764) — Replaced `window.addEventListener` and `window.ui` with `globalThis`. `window` is browser-only; `globalThis` is the spec-defined universal global, future-proofing the snippet against non-browser environments.

- **Job-level `packages: write`** (`.github/workflows/publish.yml`, S8233) — Removed `packages: write` from the workflow-level `permissions` block and added it individually to `publish-typescript` and `publish-java`. `contents: read` remains at workflow level as a restrictive default. This ensures only the jobs that actually publish carry the write grant.

## How to verify

1. Open `docs/index.html` in a browser — the Swagger UI should load normally (SRI hash mismatch would produce a console error and blank page).
2. Check that both `publish-typescript` and `publish-java` jobs in the workflow still have `packages: write` and the workflow-level block only contains `contents: read`.
3. After merge, confirm SonarQube clears all 4 issues on the next analysis.